### PR TITLE
Route root index to pit scout for all users

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,7 @@
+import { Redirect } from 'expo-router';
+
+import { ROUTES } from '@/constants/routes';
+
+export default function Index() {
+  return <Redirect href={ROUTES.pitScout} />;
+}


### PR DESCRIPTION
## Summary
- remove the authentication check on the Expo Router index route
- always send users to the pit scout drawer route so the app is usable without logging in

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e67c2e557c8326a6f26ff85eb0bc7d