### PR TITLE
Add initial Drizzle SQLite schema setup

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -1,0 +1,64 @@
+import { drizzle } from 'drizzle-orm/expo-sqlite';
+import { openDatabaseSync } from 'expo-sqlite/next';
+
+import * as schema from './schema';
+
+const sqlite = openDatabaseSync('scouting-app.db');
+
+sqlite.execSync('PRAGMA foreign_keys = ON;');
+
+const createStatements = [
+  `CREATE TABLE IF NOT EXISTS teamrecord (
+    team_number INTEGER PRIMARY KEY NOT NULL,
+    team_name TEXT NOT NULL,
+    location TEXT
+  );`,
+  `CREATE TABLE IF NOT EXISTS frcevent (
+    event_key TEXT PRIMARY KEY NOT NULL,
+    event_name TEXT NOT NULL,
+    short_name TEXT,
+    year INTEGER NOT NULL,
+    week INTEGER NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS season (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    year INTEGER NOT NULL,
+    name TEXT NOT NULL
+  );`,
+  `CREATE TABLE IF NOT EXISTS matchschedule (
+    event_key TEXT NOT NULL,
+    match_number INTEGER NOT NULL,
+    match_level TEXT NOT NULL,
+    red1_id INTEGER NOT NULL,
+    red2_id INTEGER NOT NULL,
+    red3_id INTEGER NOT NULL,
+    blue1_id INTEGER NOT NULL,
+    blue2_id INTEGER NOT NULL,
+    blue3_id INTEGER NOT NULL,
+    PRIMARY KEY (event_key, match_number, match_level),
+    FOREIGN KEY (event_key) REFERENCES frcevent(event_key),
+    FOREIGN KEY (red1_id) REFERENCES teamrecord(team_number),
+    FOREIGN KEY (red2_id) REFERENCES teamrecord(team_number),
+    FOREIGN KEY (red3_id) REFERENCES teamrecord(team_number),
+    FOREIGN KEY (blue1_id) REFERENCES teamrecord(team_number),
+    FOREIGN KEY (blue2_id) REFERENCES teamrecord(team_number),
+    FOREIGN KEY (blue3_id) REFERENCES teamrecord(team_number)
+  );`,
+  `CREATE TABLE IF NOT EXISTS teamevent (
+    event_key TEXT NOT NULL,
+    team_number INTEGER NOT NULL,
+    PRIMARY KEY (event_key, team_number),
+    FOREIGN KEY (event_key) REFERENCES frcevent(event_key),
+    FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
+  );`,
+];
+
+for (const statement of createStatements) {
+  sqlite.execSync(statement);
+}
+
+export const db = drizzle(sqlite, { schema });
+
+export type Database = typeof db;
+
+export { schema };

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,0 +1,111 @@
+import { integer, primaryKey, sqliteTable, text, foreignKey } from 'drizzle-orm/sqlite-core';
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+
+export const teamRecords = sqliteTable('teamrecord', {
+  teamNumber: integer('team_number').primaryKey(),
+  teamName: text('team_name').notNull(),
+  location: text('location'),
+});
+
+export type TeamRecord = InferSelectModel<typeof teamRecords>;
+export type NewTeamRecord = InferInsertModel<typeof teamRecords>;
+
+export const frcEvents = sqliteTable('frcevent', {
+  eventKey: text('event_key').primaryKey(),
+  eventName: text('event_name').notNull(),
+  shortName: text('short_name'),
+  year: integer('year').notNull(),
+  week: integer('week').notNull(),
+});
+
+export type FRCEvent = InferSelectModel<typeof frcEvents>;
+export type NewFRCEvent = InferInsertModel<typeof frcEvents>;
+
+export const seasons = sqliteTable('season', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  year: integer('year').notNull(),
+  name: text('name').notNull(),
+});
+
+export type Season = InferSelectModel<typeof seasons>;
+export type NewSeason = InferInsertModel<typeof seasons>;
+
+export const matchSchedules = sqliteTable(
+  'matchschedule',
+  {
+    eventKey: text('event_key').notNull(),
+    matchNumber: integer('match_number').notNull(),
+    matchLevel: text('match_level').notNull(),
+    red1Id: integer('red1_id').notNull(),
+    red2Id: integer('red2_id').notNull(),
+    red3Id: integer('red3_id').notNull(),
+    blue1Id: integer('blue1_id').notNull(),
+    blue2Id: integer('blue2_id').notNull(),
+    blue3Id: integer('blue3_id').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.eventKey, table.matchNumber, table.matchLevel] }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'matchschedule_event_fk',
+    }),
+    red1Ref: foreignKey({
+      columns: [table.red1Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_red1_fk',
+    }),
+    red2Ref: foreignKey({
+      columns: [table.red2Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_red2_fk',
+    }),
+    red3Ref: foreignKey({
+      columns: [table.red3Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_red3_fk',
+    }),
+    blue1Ref: foreignKey({
+      columns: [table.blue1Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_blue1_fk',
+    }),
+    blue2Ref: foreignKey({
+      columns: [table.blue2Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_blue2_fk',
+    }),
+    blue3Ref: foreignKey({
+      columns: [table.blue3Id],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'matchschedule_blue3_fk',
+    }),
+  }),
+);
+
+export type MatchSchedule = InferSelectModel<typeof matchSchedules>;
+export type NewMatchSchedule = InferInsertModel<typeof matchSchedules>;
+
+export const teamEvents = sqliteTable(
+  'teamevent',
+  {
+    eventKey: text('event_key').notNull(),
+    teamNumber: integer('team_number').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.eventKey, table.teamNumber] }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'teamevent_event_fk',
+    }),
+    teamRef: foreignKey({
+      columns: [table.teamNumber],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'teamevent_team_fk',
+    }),
+  }),
+);
+
+export type TeamEvent = InferSelectModel<typeof teamEvents>;
+export type NewTeamEvent = InferInsertModel<typeof teamEvents>;


### PR DESCRIPTION
## Summary
- add Drizzle ORM table definitions for teams, events, seasons, match schedules, and team-event participation
- configure the expo SQLite-backed Drizzle client and ensure the required tables are created on startup

## Testing
- n/a (not run: offline environment missing drizzle-orm package for TypeScript)

------
https://chatgpt.com/codex/tasks/task_e_68e68396b8d0832697857d281b440c24