### PR TITLE
Initialize SQLite database during app startup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,8 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import '@/db'; // Initialize the SQLite-backed storage on startup.
+
 import { AuthProvider, OrganizationProvider } from '@/app/providers';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 


### PR DESCRIPTION
## Summary
- import the database module in the root layout so the SQLite schema is initialized when the app loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6870aceac83269bfadd56e1f56d85