### PR TITLE
Guard SQLite setup from server environments

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,13 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+if (!config.resolver.assetExts.includes('wasm')) {
+  config.resolver.assetExts.push('wasm');
+}
+
+config.resolver.sourceExts = config.resolver.sourceExts.filter(
+  (ext) => ext !== 'wasm'
+);
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- skip expo-sqlite initialization when running in server runtimes and surface a helpful warning instead of crashing
- lazily build the Drizzle client only when a native SQLite database is available and expose a helper to access it safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6890079148326986a84b54bf6637d