### PR TITLE
Configure API client for development and platform stubs

### DIFF
--- a/app/services/api/base.ts
+++ b/app/services/api/base.ts
@@ -1,0 +1,44 @@
+import { Platform } from 'react-native';
+
+const DEV_WEB_BASE_URL = 'http://localhost:5173';
+
+/**
+ * Returns the base API url when the app is running in a web browser.
+ * In development we point to localhost to hit the dev server directly.
+ */
+const getWebBaseUrl = () => {
+  if (__DEV__) {
+    return DEV_WEB_BASE_URL;
+  }
+
+  return getWebProductionBaseUrl();
+};
+
+/**
+ * Stub for retrieving the production API URL for the web build.
+ * Replace the return value when the production endpoint is known.
+ */
+export const getWebProductionBaseUrl = () => {
+  // TODO: configure the production API url once it is available.
+  return 'https://api.production.example.com';
+};
+
+/**
+ * Stub for retrieving the base API URL for native mobile builds.
+ * This should be updated to point at the correct backend for mobile usage.
+ */
+export const getMobileBaseUrl = () => {
+  // TODO: configure the mobile API url once it is available.
+  return 'https://api.mobile.example.com';
+};
+
+/**
+ * Resolve the base API url for the current platform/environment.
+ */
+export const getBaseApiUrl = () => {
+  if (Platform.OS === 'web') {
+    return getWebBaseUrl();
+  }
+
+  return getMobileBaseUrl();
+};

--- a/app/services/api/client.ts
+++ b/app/services/api/client.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+import { getBaseApiUrl } from './base';
+
+export const apiClient = axios.create({
+  baseURL: getBaseApiUrl(),
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export const setAuthorizationToken = (token?: string) => {
+  if (token) {
+    apiClient.defaults.headers.common.Authorization = `Bearer ${token}`;
+    return;
+  }
+
+  delete apiClient.defaults.headers.common.Authorization;
+};

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './client';


### PR DESCRIPTION
## Summary
- add base API url resolution with dev web pointing to localhost:5173
- stub functions to supply web production and native mobile API base urls
- create a shared axios client configured with the resolved base url

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e69f72c55c83269aa35e6b9b8da181