### PR TITLE
Display API ping response on PitScout screen

### DIFF
--- a/app/screens/PitScout/PitScoutScreen.tsx
+++ b/app/screens/PitScout/PitScoutScreen.tsx
@@ -1,12 +1,63 @@
+import { useEffect, useState } from 'react';
+
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
+import { apiClient } from '@/app/services/api/client';
 
 export function PitScoutScreen() {
+  const [pingResponse, setPingResponse] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadPing = async () => {
+      if (!isMounted) {
+        return;
+      }
+
+      setPingResponse(null);
+      setError(null);
+
+      try {
+        const { data } = await apiClient.get('/public/ping');
+
+        if (!isMounted) {
+          return;
+        }
+
+        setPingResponse(JSON.stringify(data, null, 2));
+      } catch (err) {
+        if (!isMounted) {
+          return;
+        }
+
+        setError(err instanceof Error ? err.message : 'Unexpected error while fetching ping response.');
+      }
+    };
+
+    loadPing();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const isLoading = !pingResponse && !error;
+
   return (
     <ScreenContainer>
       <ThemedText type="title">Pit Scouting</ThemedText>
       <ThemedText>
         Capture robot configurations, drivetrain specifications, and pre-match notes while visiting the pit.
+      </ThemedText>
+      <ThemedText type="subtitle" style={{ marginTop: 24 }}>
+        API Connectivity Check
+      </ThemedText>
+      <ThemedText selectable style={{ marginTop: 8 }}>
+        {isLoading && 'Loading ping response...'}
+        {error && !isLoading && `Error loading ping response: ${error}`}
+        {pingResponse && !isLoading && pingResponse}
       </ThemedText>
     </ScreenContainer>
   );


### PR DESCRIPTION
## Summary
- fetch the /public/ping endpoint when the PitScout screen mounts
- surface the JSON payload along with loading and error messaging for easy verification

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6bb726594832681548b9d952dddfb