### PR TITLE
feat: configure Drizzle to use IndexedDB on web

### DIFF
--- a/db/index.web.ts
+++ b/db/index.web.ts
@@ -2,13 +2,12 @@ import { getDbOrThrow } from './index.shared';
 
 if (typeof window !== 'undefined') {
   try {
-    // Force eagerly opening the SQLite database on the client so the Expo WASM
-    // worker sets up its persistent backing store (IndexedDB/OPFS) before the
-    // rest of the app tries to run queries.
+    // Force eagerly opening the web database so IndexedDB storage is ready
+    // before the rest of the app tries to run queries.
     getDbOrThrow();
   } catch (error) {
     console.warn(
-      'SQLite is unavailable on this web build; falling back to in-memory mode.',
+      'IndexedDB is unavailable on this web build; persistence will be disabled.',
       error
     );
   }


### PR DESCRIPTION
## Summary
- configure the shared Drizzle setup to detect the current platform and initialize the appropriate driver
- use a localforage-backed IndexedDB database on the web while keeping Expo SQLite on native builds
- adjust the web entrypoint logging to reflect the IndexedDB persistence fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c5b61cd08326b72a12600488279b