### PR TITLE
feat: add match schedule UI components

### DIFF
--- a/app/screens/MatchScout/MatchScoutScreen.tsx
+++ b/app/screens/MatchScout/MatchScoutScreen.tsx
@@ -1,13 +1,76 @@
+import { useMemo, useState } from 'react';
+
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import {
+  MatchSchedule,
+  MatchScheduleEntry,
+  MatchScheduleSection,
+  MatchScheduleToggle,
+  SECTION_DEFINITIONS,
+  groupMatchesBySection,
+} from '@/components/match-schedule';
 import { ThemedText } from '@/components/themed-text';
 
+const MOCK_MATCHES: MatchScheduleEntry[] = [
+  {
+    match_number: 1,
+    match_level: 'qm',
+    red1_id: 111,
+    red2_id: 222,
+    red3_id: 333,
+    blue1_id: 444,
+    blue2_id: 555,
+    blue3_id: 666,
+  },
+  {
+    match_number: 2,
+    match_level: 'qm',
+    red1_id: 777,
+    red2_id: 888,
+    red3_id: 999,
+    blue1_id: 1010,
+    blue2_id: 1111,
+    blue3_id: 1212,
+  },
+  {
+    match_number: 1,
+    match_level: 'sf',
+    red1_id: 1313,
+    red2_id: 1414,
+    red3_id: 1515,
+    blue1_id: 1616,
+    blue2_id: 1717,
+    blue3_id: 1818,
+  },
+  {
+    match_number: 1,
+    match_level: 'f',
+    red1_id: 1919,
+    red2_id: 2020,
+    red3_id: 2121,
+    blue1_id: 2222,
+    blue2_id: 2323,
+    blue3_id: 2424,
+  },
+];
+
 export function MatchScoutScreen() {
+  const [selectedSection, setSelectedSection] = useState<MatchScheduleSection>('qualification');
+
+  const groupedMatches = useMemo(() => groupMatchesBySection(MOCK_MATCHES), []);
+
   return (
     <ScreenContainer>
       <ThemedText type="title">Match Scouting</ThemedText>
       <ThemedText>
         Record match performance, scoring actions, and alliance notes in real time.
       </ThemedText>
+      <MatchScheduleToggle
+        value={selectedSection}
+        onChange={setSelectedSection}
+        options={SECTION_DEFINITIONS}
+      />
+      <MatchSchedule matches={groupedMatches[selectedSection]} />
     </ScreenContainer>
   );
 }

--- a/components/match-schedule/constants.ts
+++ b/components/match-schedule/constants.ts
@@ -1,0 +1,39 @@
+import type { MatchScheduleEntry } from './types';
+
+export type MatchScheduleSection = 'qualification' | 'playoffs' | 'finals';
+
+export interface MatchScheduleToggleOption {
+  label: string;
+  value: MatchScheduleSection;
+}
+
+export const SECTION_DEFINITIONS: readonly {
+  value: MatchScheduleSection;
+  label: string;
+}[] = [
+  { value: 'qualification', label: 'Qualification' },
+  { value: 'playoffs', label: 'Playoffs' },
+  { value: 'finals', label: 'Finals' },
+];
+
+export const groupMatchesBySection = (matches: MatchScheduleEntry[]) => {
+  const grouped: Record<MatchScheduleSection, MatchScheduleEntry[]> = {
+    qualification: [],
+    playoffs: [],
+    finals: [],
+  };
+
+  matches.forEach((match) => {
+    const matchLevel = match.match_level?.toLowerCase();
+
+    if (matchLevel === 'qm') {
+      grouped.qualification.push(match);
+    } else if (matchLevel === 'sf') {
+      grouped.playoffs.push(match);
+    } else if (matchLevel === 'f') {
+      grouped.finals.push(match);
+    }
+  });
+
+  return grouped;
+};

--- a/components/match-schedule/index.ts
+++ b/components/match-schedule/index.ts
@@ -1,0 +1,5 @@
+export * from './constants';
+export * from './match-number-button-menu';
+export * from './match-schedule';
+export * from './match-schedule-toggle';
+export * from './types';

--- a/components/match-schedule/match-number-button-menu.tsx
+++ b/components/match-schedule/match-number-button-menu.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'expo-router';
+import { Pressable, StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+interface MatchNumberButtonMenuProps {
+  matchNumber: number;
+  matchLevel: string;
+}
+
+export function MatchNumberButtonMenu({ matchNumber, matchLevel }: MatchNumberButtonMenuProps) {
+  const tintColor = useThemeColor({}, 'tint');
+  const borderColor = useThemeColor({}, 'icon');
+
+  return (
+    <Link
+      asChild
+      href={`/matches/preview/${matchLevel}/${matchNumber}`}
+      accessibilityLabel={`Preview match ${matchNumber}`}
+    >
+      <Pressable style={({ pressed }) => [styles.button, { borderColor }, pressed && styles.pressed]}>
+        <ThemedText type="defaultSemiBold" style={[styles.label, { color: tintColor }]}>
+          Match {matchNumber}
+        </ThemedText>
+      </Pressable>
+    </Link>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 96,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+  label: {
+    fontSize: 14,
+  },
+});

--- a/components/match-schedule/match-schedule-toggle.tsx
+++ b/components/match-schedule/match-schedule-toggle.tsx
@@ -1,0 +1,101 @@
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+import type { MatchScheduleSection, MatchScheduleToggleOption } from './constants';
+
+interface MatchScheduleToggleProps {
+  value: MatchScheduleSection;
+  options: MatchScheduleToggleOption[];
+  onChange: (value: MatchScheduleSection) => void;
+}
+
+export function MatchScheduleToggle({ value, options, onChange }: MatchScheduleToggleProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  return (
+    <View
+      style={[
+        styles.root,
+        {
+          backgroundColor: isDark ? 'rgba(23, 23, 23, 0.9)' : '#FFFFFF',
+          borderColor: isDark ? 'rgba(75, 85, 99, 0.6)' : 'rgba(209, 213, 219, 0.9)',
+        },
+      ]}
+    >
+      {options.map((option) => {
+        const isActive = option.value === value;
+
+        return (
+          <Pressable
+            key={option.value}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+            style={({ pressed }) => [
+              styles.control,
+              isActive && [styles.controlActive, isDark ? styles.controlActiveDark : styles.controlActiveLight],
+              pressed && styles.controlPressed,
+            ]}
+            onPress={() => onChange(option.value)}
+          >
+            <ThemedText
+              type="defaultSemiBold"
+              style={[
+                styles.label,
+                isActive && (isDark ? styles.labelActiveDark : styles.labelActiveLight),
+              ]}
+            >
+              {option.label}
+            </ThemedText>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: 'row',
+    borderRadius: 999,
+    padding: 4,
+    borderWidth: 1,
+    gap: 4,
+    alignItems: 'center',
+  },
+  control: {
+    flex: 1,
+    borderRadius: 999,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  controlActive: {
+    shadowColor: '#f97316',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.35,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  controlActiveLight: {
+    backgroundColor: '#f97316',
+  },
+  controlActiveDark: {
+    backgroundColor: '#db2777',
+  },
+  controlPressed: {
+    opacity: 0.85,
+  },
+  label: {
+    fontSize: 14,
+  },
+  labelActiveLight: {
+    color: '#FFFFFF',
+  },
+  labelActiveDark: {
+    color: '#FFFFFF',
+  },
+});

--- a/components/match-schedule/match-schedule.tsx
+++ b/components/match-schedule/match-schedule.tsx
@@ -1,0 +1,388 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+import { MatchNumberButtonMenu } from './match-number-button-menu';
+import type { MatchScheduleEntry, TeamMatchValidationEntry } from './types';
+
+interface RowData {
+  matchNumber: number;
+  matchLevel: string;
+  red1?: number | null;
+  red2?: number | null;
+  red3?: number | null;
+  blue1?: number | null;
+  blue2?: number | null;
+  blue3?: number | null;
+  played?: boolean;
+}
+
+interface MatchScheduleProps {
+  matches: MatchScheduleEntry[];
+  validationEntries?: TeamMatchValidationEntry[];
+  isValidationLoading?: boolean;
+  isValidationError?: boolean;
+}
+
+const teamNumberKeys: (keyof RowData)[] = ['red1', 'red2', 'red3', 'blue1', 'blue2', 'blue3'];
+
+const createMatchKey = (matchLevel: string, matchNumber: number) =>
+  `${matchLevel.toLowerCase()}-${matchNumber}`;
+
+const createRowData = (
+  matches: MatchScheduleEntry[],
+  playedMatches?: Set<string>,
+  isValidationReady?: boolean
+): RowData[] =>
+  matches.map((match) => {
+    const matchKey = createMatchKey(match.match_level, match.match_number);
+
+    return {
+      matchNumber: match.match_number,
+      matchLevel: match.match_level,
+      red1: match.red1_id,
+      red2: match.red2_id,
+      red3: match.red3_id,
+      blue1: match.blue1_id,
+      blue2: match.blue2_id,
+      blue3: match.blue3_id,
+      played: isValidationReady ? playedMatches?.has(matchKey) ?? false : undefined,
+    };
+  });
+
+function filterData(
+  data: RowData[],
+  { matchSearch, teamSearch }: { matchSearch: string; teamSearch: string }
+) {
+  const matchQuery = matchSearch.trim();
+  const matchNumberQuery = Number(matchQuery);
+  const teamQuery = teamSearch.toLowerCase().trim();
+
+  return data.filter((item) => {
+    const matchMatches = matchQuery
+      ? !Number.isNaN(matchNumberQuery) && item.matchNumber === matchNumberQuery
+      : true;
+
+    const teamMatches = teamQuery
+      ? teamNumberKeys.some((key) => {
+          const teamNumber = item[key];
+          if (teamNumber === null || teamNumber === undefined) {
+            return false;
+          }
+
+          return teamNumber.toString().toLowerCase() === teamQuery;
+        })
+      : true;
+
+    return matchMatches && teamMatches;
+  });
+}
+
+function sortData(
+  data: RowData[],
+  payload: { reversed: boolean; matchSearch: string; teamSearch: string }
+) {
+  const sorted = [...data].sort((a, b) =>
+    payload.reversed ? b.matchNumber - a.matchNumber : a.matchNumber - b.matchNumber
+  );
+
+  return filterData(sorted, { matchSearch: payload.matchSearch, teamSearch: payload.teamSearch });
+}
+
+const renderTeamNumber = (value?: number | null) => (value === null || value === undefined ? '-' : value);
+
+export function MatchSchedule({
+  matches,
+  validationEntries,
+  isValidationError = false,
+  isValidationLoading = false,
+}: MatchScheduleProps) {
+  const [matchSearch, setMatchSearch] = useState('');
+  const [teamSearch, setTeamSearch] = useState('');
+  const [reverseSortDirection, setReverseSortDirection] = useState(false);
+
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === 'dark';
+  const textColor = useThemeColor({}, 'text');
+  const iconColor = useThemeColor({}, 'icon');
+
+  const isValidationReady =
+    !isValidationLoading && !isValidationError && validationEntries !== undefined;
+
+  const playedMatches = useMemo(() => {
+    if (!isValidationReady || !validationEntries) {
+      return undefined;
+    }
+
+    const played = new Set<string>();
+    validationEntries.forEach((entry) => {
+      played.add(createMatchKey(entry.match_level, entry.match_number));
+    });
+
+    return played;
+  }, [validationEntries, isValidationReady]);
+
+  const schedule = useMemo(
+    () => createRowData(matches, playedMatches, isValidationReady),
+    [matches, playedMatches, isValidationReady]
+  );
+
+  const sortedData = useMemo(
+    () => sortData(schedule, { reversed: reverseSortDirection, matchSearch, teamSearch }),
+    [schedule, reverseSortDirection, matchSearch, teamSearch]
+  );
+
+  const toggleSortDirection = () => {
+    setReverseSortDirection((current) => !current);
+  };
+
+  const placeholderColor = isDark ? 'rgba(148, 163, 184, 0.9)' : 'rgba(100, 116, 139, 0.9)';
+  const inputBorderColor = isDark ? 'rgba(63, 63, 70, 0.8)' : 'rgba(209, 213, 219, 0.9)';
+  const inputBackground = isDark ? 'rgba(39, 39, 42, 0.7)' : '#F9FAFB';
+  const dividerColor = isDark ? 'rgba(63, 63, 70, 0.8)' : 'rgba(229, 231, 235, 0.9)';
+  const headerBackground = isDark ? 'rgba(30, 41, 59, 0.8)' : 'rgba(226, 232, 240, 0.8)';
+  const headerTextColor = isDark ? '#E2E8F0' : '#1E293B';
+  const redCellBackground = isDark ? 'rgba(127, 29, 29, 0.6)' : '#FEE2E2';
+  const redCellText = isDark ? '#FECACA' : '#7F1D1D';
+  const blueCellBackground = isDark ? 'rgba(30, 64, 175, 0.6)' : '#DBEAFE';
+  const blueCellText = isDark ? '#BFDBFE' : '#1E3A8A';
+  const pendingTextColor = isDark ? 'rgba(156, 163, 175, 0.8)' : 'rgba(107, 114, 128, 0.9)';
+
+  const rows = sortedData.map((row) => (
+    <View key={`${row.matchLevel}-${row.matchNumber}`} style={[styles.row, { borderColor: dividerColor }]}>
+      <View style={[styles.cell, styles.matchCell]}> 
+        <MatchNumberButtonMenu matchNumber={row.matchNumber} matchLevel={row.matchLevel} />
+      </View>
+      <View style={[styles.cell, { backgroundColor: redCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: redCellText }]}> 
+          {renderTeamNumber(row.red1)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, { backgroundColor: redCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: redCellText }]}> 
+          {renderTeamNumber(row.red2)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, { backgroundColor: redCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: redCellText }]}> 
+          {renderTeamNumber(row.red3)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, { backgroundColor: blueCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: blueCellText }]}> 
+          {renderTeamNumber(row.blue1)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, { backgroundColor: blueCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: blueCellText }]}> 
+          {renderTeamNumber(row.blue2)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, { backgroundColor: blueCellBackground }]}> 
+        <ThemedText style={[styles.cellText, { color: blueCellText }]}> 
+          {renderTeamNumber(row.blue3)}
+        </ThemedText>
+      </View>
+      <View style={[styles.cell, styles.statusCell]}> 
+        {row.played === undefined ? (
+          <ThemedText style={[styles.statusText, { color: pendingTextColor }]}>N/A</ThemedText>
+        ) : row.played ? (
+          <Ionicons name="checkmark-circle" size={26} color="#22c55e" />
+        ) : (
+          <Ionicons name="close-circle" size={26} color="#ef4444" />
+        )}
+      </View>
+    </View>
+  ));
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.filters}>
+        <View style={[styles.inputWrapper, { borderColor: inputBorderColor, backgroundColor: inputBackground }]}> 
+          <Ionicons name="search" size={16} color={iconColor} style={styles.inputIcon} />
+          <TextInput
+            placeholder="Filter by match number"
+            placeholderTextColor={placeholderColor}
+            value={matchSearch}
+            onChangeText={setMatchSearch}
+            style={[styles.input, { color: textColor }]}
+            keyboardType="numeric"
+          />
+        </View>
+        <View style={[styles.inputWrapper, { borderColor: inputBorderColor, backgroundColor: inputBackground }]}> 
+          <Ionicons name="search" size={16} color={iconColor} style={styles.inputIcon} />
+          <TextInput
+            placeholder="Filter by team number"
+            placeholderTextColor={placeholderColor}
+            value={teamSearch}
+            onChangeText={setTeamSearch}
+            style={[styles.input, { color: textColor }]}
+            keyboardType="numeric"
+          />
+        </View>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={[styles.table, { borderColor: dividerColor }]}> 
+          <View style={[styles.row, styles.headerRow, { backgroundColor: headerBackground, borderColor: dividerColor }]}> 
+            <View style={[styles.cell, styles.headerCell, styles.matchCell]}> 
+              <PressableSortButton
+                label="Match #"
+                iconColor={headerTextColor}
+                isReversed={reverseSortDirection}
+                onPress={toggleSortDirection}
+              />
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Red 1</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Red 2</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Red 3</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Blue 1</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Blue 2</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Blue 3</ThemedText>
+            </View>
+            <View style={[styles.cell, styles.headerCell, styles.statusCell]}> 
+              <ThemedText style={[styles.headerText, { color: headerTextColor }]}>Played</ThemedText>
+            </View>
+          </View>
+          {rows.length > 0 ? (
+            rows
+          ) : (
+            <View style={[styles.emptyState, { borderColor: dividerColor }]}> 
+              <ThemedText type="defaultSemiBold" style={[styles.emptyStateText, { color: textColor }]}> 
+                Nothing found
+              </ThemedText>
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </ScrollView>
+  );
+}
+
+interface PressableSortButtonProps {
+  label: string;
+  iconColor: string;
+  isReversed: boolean;
+  onPress: () => void;
+}
+
+function PressableSortButton({ label, iconColor, isReversed, onPress }: PressableSortButtonProps) {
+  return (
+    <View style={styles.sortButtonContainer}>
+      <Pressable
+        style={({ pressed }) => [styles.sortButton, pressed && styles.sortButtonPressed]}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`Sort by ${label}`}
+      >
+        <ThemedText style={[styles.headerText, { color: iconColor }]}>{label}</ThemedText>
+        <Ionicons
+          name={isReversed ? 'chevron-down' : 'chevron-up'}
+          size={16}
+          color={iconColor}
+        />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    paddingBottom: 24,
+  },
+  filters: {
+    gap: 12,
+  },
+  inputWrapper: {
+    borderRadius: 12,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+  },
+  inputIcon: {
+    marginRight: 8,
+  },
+  input: {
+    flex: 1,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  table: {
+    borderWidth: 1,
+    borderRadius: 16,
+    overflow: 'hidden',
+    minWidth: 640,
+  },
+  row: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+  },
+  headerRow: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  cell: {
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 90,
+  },
+  matchCell: {
+    minWidth: 130,
+  },
+  headerCell: {
+    backgroundColor: 'transparent',
+  },
+  headerText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  cellText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  statusCell: {
+    minWidth: 100,
+  },
+  statusText: {
+    fontSize: 14,
+  },
+  sortButtonContainer: {
+    width: '100%',
+  },
+  sortButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  sortButtonPressed: {
+    opacity: 0.85,
+  },
+  emptyState: {
+    paddingVertical: 32,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderTopWidth: 1,
+  },
+  emptyStateText: {
+    textAlign: 'center',
+  },
+});

--- a/components/match-schedule/types.ts
+++ b/components/match-schedule/types.ts
@@ -1,0 +1,15 @@
+export interface MatchScheduleEntry {
+  match_number: number;
+  match_level: string;
+  red1_id?: number | null;
+  red2_id?: number | null;
+  red3_id?: number | null;
+  blue1_id?: number | null;
+  blue2_id?: number | null;
+  blue3_id?: number | null;
+}
+
+export interface TeamMatchValidationEntry {
+  match_number: number;
+  match_level: string;
+}


### PR DESCRIPTION
## Summary
- add a reusable MatchSchedule component with filtering, sorting, and status indicators
- create supporting match schedule toggle, constants, and types for grouping matches
- surface the new schedule UI on the Match Scout screen with placeholder grouped data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6d0a80034832685a9f3cf2ecd7f68