### PR TITLE
Restyle match schedule layout

### DIFF
--- a/components/match-schedule/match-schedule.tsx
+++ b/components/match-schedule/match-schedule.tsx
@@ -111,66 +111,70 @@ export function MatchSchedule({
   const dividerColor = isDark ? 'rgba(63, 63, 70, 0.6)' : 'rgba(226, 232, 240, 0.9)';
   const cardBackground = isDark ? 'rgba(24, 24, 27, 0.85)' : '#FFFFFF';
   const headerTextColor = isDark ? '#F8FAFC' : '#0F172A';
-  const redCellBackground = isDark ? 'rgba(127, 29, 29, 0.7)' : '#B91C1C';
-  const blueCellBackground = isDark ? 'rgba(30, 64, 175, 0.7)' : '#1D4ED8';
-  const redCellText = '#F8FAFC';
-  const blueCellText = '#F8FAFC';
+  const teamCellBackground = isDark ? 'rgba(39, 39, 42, 0.75)' : '#F1F5F9';
+  const teamCellBorder = isDark ? 'rgba(82, 82, 91, 0.6)' : 'rgba(203, 213, 225, 0.9)';
+  const teamCellText = isDark ? '#E2E8F0' : '#0F172A';
   const pendingTextColor = isDark ? 'rgba(156, 163, 175, 0.8)' : 'rgba(107, 114, 128, 0.9)';
 
   const rows = schedule.map((row) => {
     const matchLabel = `${getMatchLevelLabel(row.matchLevel)} ${row.matchNumber}`;
+    const teamPairs = [
+      { id: '1', red: row.red1, blue: row.blue1 },
+      { id: '2', red: row.red2, blue: row.blue2 },
+      { id: '3', red: row.red3, blue: row.blue3 },
+    ];
 
     return (
       <View
         key={`${row.matchLevel}-${row.matchNumber}`}
         style={[styles.matchCard, { backgroundColor: cardBackground, borderColor: dividerColor }]}
       >
-        <View style={styles.matchCardHeader}>
-          <ThemedText type="defaultSemiBold" style={[styles.matchLabel, { color: headerTextColor }]}>
-            {matchLabel}
-          </ThemedText>
-          <View style={styles.matchStatusWrapper}>
-            {row.played === undefined ? (
-              <ThemedText style={[styles.statusText, { color: pendingTextColor }]}>Pending</ThemedText>
-            ) : row.played ? (
-              <View style={styles.statusIndicator}>
-                <Ionicons name="checkmark-circle" size={20} color="#22c55e" />
-                <ThemedText style={styles.statusSuccess}>Played</ThemedText>
-              </View>
-            ) : (
-              <View style={styles.statusIndicator}>
-                <Ionicons name="close-circle" size={20} color="#ef4444" />
-                <ThemedText style={styles.statusError}>Unplayed</ThemedText>
-              </View>
-            )}
+        <View style={styles.matchLayout}>
+          <View style={styles.matchInfoColumn}>
+            <ThemedText type="title" style={[styles.matchLabel, { color: headerTextColor }]}>
+              {matchLabel}
+            </ThemedText>
+            <View style={styles.matchStatusWrapper}>
+              {row.played === undefined ? (
+                <ThemedText style={[styles.statusText, { color: pendingTextColor }]}>Pending</ThemedText>
+              ) : row.played ? (
+                <View style={styles.statusIndicator}>
+                  <Ionicons name="checkmark-circle" size={20} color="#22c55e" />
+                  <ThemedText style={styles.statusSuccess}>Played</ThemedText>
+                </View>
+              ) : (
+                <View style={styles.statusIndicator}>
+                  <Ionicons name="close-circle" size={20} color="#ef4444" />
+                  <ThemedText style={styles.statusError}>Unplayed</ThemedText>
+                </View>
+              )}
+            </View>
           </View>
-        </View>
-        <View style={[styles.allianceRow, { backgroundColor: redCellBackground }]}>
-          <ThemedText style={[styles.allianceLabel, { color: redCellText }]}>Red</ThemedText>
-          <View style={styles.teamList}>
-            <ThemedText style={[styles.teamNumber, { color: redCellText }]}>
-              {renderTeamNumber(row.red1)}
-            </ThemedText>
-            <ThemedText style={[styles.teamNumber, { color: redCellText }]}>
-              {renderTeamNumber(row.red2)}
-            </ThemedText>
-            <ThemedText style={[styles.teamNumber, { color: redCellText }]}>
-              {renderTeamNumber(row.red3)}
-            </ThemedText>
-          </View>
-        </View>
-        <View style={[styles.allianceRow, { backgroundColor: blueCellBackground }]}>
-          <ThemedText style={[styles.allianceLabel, { color: blueCellText }]}>Blue</ThemedText>
-          <View style={styles.teamList}>
-            <ThemedText style={[styles.teamNumber, { color: blueCellText }]}>
-              {renderTeamNumber(row.blue1)}
-            </ThemedText>
-            <ThemedText style={[styles.teamNumber, { color: blueCellText }]}>
-              {renderTeamNumber(row.blue2)}
-            </ThemedText>
-            <ThemedText style={[styles.teamNumber, { color: blueCellText }]}>
-              {renderTeamNumber(row.blue3)}
-            </ThemedText>
+          <View style={styles.teamGrid}>
+            {teamPairs.map((pair) => (
+              <View key={pair.id} style={styles.teamRow}>
+                <View
+                  style={[
+                    styles.teamCell,
+                    { backgroundColor: teamCellBackground, borderColor: teamCellBorder },
+                  ]}
+                >
+                  <ThemedText style={[styles.teamNumber, { color: teamCellText }]}>
+                    {renderTeamNumber(pair.red)}
+                  </ThemedText>
+                </View>
+                <View
+                  style={[
+                    styles.teamCell,
+                    { backgroundColor: teamCellBackground, borderColor: teamCellBorder },
+                  ]}
+                >
+                  <ThemedText style={[styles.teamNumber, { color: teamCellText }]}>
+                    {renderTeamNumber(pair.blue)}
+                  </ThemedText>
+                </View>
+              </View>
+            ))}
           </View>
         </View>
       </View>
@@ -204,18 +208,21 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     borderWidth: 1,
     padding: 16,
-    gap: 12,
   },
-  matchCardHeader: {
+  matchLayout: {
     flexDirection: 'row',
+    gap: 16,
+  },
+  matchInfoColumn: {
+    flex: 1,
     justifyContent: 'space-between',
-    alignItems: 'center',
   },
   matchLabel: {
-    fontSize: 18,
+    fontSize: 20,
   },
   matchStatusWrapper: {
-    alignItems: 'flex-end',
+    alignItems: 'flex-start',
+    gap: 8,
   },
   statusIndicator: {
     flexDirection: 'row',
@@ -223,7 +230,8 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   statusText: {
-    fontSize: 14,
+    fontSize: 16,
+    fontWeight: '600',
   },
   statusSuccess: {
     fontSize: 14,
@@ -235,26 +243,26 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#ef4444',
   },
-  allianceRow: {
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  allianceLabel: {
-    fontSize: 16,
-    fontWeight: '700',
-  },
-  teamList: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
   teamNumber: {
     fontSize: 18,
     fontWeight: '700',
+  },
+  teamGrid: {
+    flex: 3,
+    gap: 12,
+  },
+  teamRow: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: 12,
+  },
+  teamCell: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
   },
   emptyState: {
     paddingVertical: 32,


### PR DESCRIPTION
## Summary
- restyle the match schedule card to place the match label and status in a left-side column and teams in a structured grid
- remove the red/blue alliance descriptors and apply neutral team number styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e722c7086883269ac56d9fdac214af