### PR TITLE
Display match team options in a single column

### DIFF
--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -203,13 +203,11 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   optionsGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+    flexDirection: 'column',
     gap: 12,
-    justifyContent: 'space-between',
   },
   teamOption: {
-    flexBasis: '48%',
+    alignSelf: 'stretch',
     paddingVertical: 16,
     paddingHorizontal: 12,
     borderRadius: 16,


### PR DESCRIPTION
## Summary
- adjust the match team selection layout to stack all alliance options in a single column for easier scanning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e72c6bc3a483268db6081ce46aea2c