### PR TITLE
Fix match scout drawer button navigation

### DIFF
--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -57,7 +57,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
               accessibilityRole="button"
               accessibilityState={isActive ? { selected: true } : undefined}
               onPress={() => {
-                navigation.navigate(item.name);
+                router.navigate(item.href);
                 navigation.closeDrawer();
               }}
               style={[styles.drawerItem, isActive && styles.drawerItemActive]}


### PR DESCRIPTION
## Summary
- update drawer item handler to navigate using route hrefs so the Match Scout button opens the schedule view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72d80af688326b0293aabad14ea36