### PR TITLE
Adjust team select and schedule layouts

### DIFF
--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -203,11 +203,14 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   optionsGrid: {
-    flexDirection: 'column',
-    gap: 12,
+    flex: 1,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-evenly',
   },
   teamOption: {
-    alignSelf: 'stretch',
+    width: '80%',
+    maxWidth: 480,
     paddingVertical: 16,
     paddingHorizontal: 12,
     borderRadius: 16,

--- a/components/match-schedule/match-schedule.tsx
+++ b/components/match-schedule/match-schedule.tsx
@@ -211,15 +211,21 @@ export function MatchSchedule({
 const styles = StyleSheet.create({
   container: {
     gap: 16,
-    paddingBottom: 24,
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    alignItems: 'center',
   },
   matchList: {
-    gap: 12,
+    width: '100%',
+    gap: 16,
+    alignItems: 'center',
   },
   matchCard: {
     borderRadius: 16,
     borderWidth: 1,
     padding: 16,
+    width: '100%',
+    marginVertical: 8,
   },
   matchLayout: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- update the match team selection layout to evenly space buttons in a full-height flex view
- adjust match schedule scrolling container so match cards center with responsive spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7c3561d60832681c03377382ffbe5