### PR TITLE
Add begin scouting flow from team selection

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -1,0 +1,53 @@
+import { StyleSheet, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+
+const toSingleValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+type BeginScoutingParams = {
+  teamNumber?: string | string[];
+  matchNumber?: string | string[];
+  eventKey?: string | string[];
+};
+
+export default function BeginScoutingRoute() {
+  const params = useLocalSearchParams<BeginScoutingParams>();
+
+  const teamNumber = toSingleValue(params.teamNumber) ?? 'Unknown';
+  const matchNumber = toSingleValue(params.matchNumber) ?? 'Unknown';
+  const eventKey = toSingleValue(params.eventKey) ?? 'Unknown';
+
+  return (
+    <ScreenContainer>
+      <View style={styles.content}>
+        <ThemedText type="title">Scouting Session</ThemedText>
+        <View style={styles.detailRow}>
+          <ThemedText type="defaultSemiBold">Team:</ThemedText>
+          <ThemedText type="default">{teamNumber}</ThemedText>
+        </View>
+        <View style={styles.detailRow}>
+          <ThemedText type="defaultSemiBold">Match:</ThemedText>
+          <ThemedText type="default">{matchNumber}</ThemedText>
+        </View>
+        <View style={styles.detailRow}>
+          <ThemedText type="defaultSemiBold">Event Key:</ThemedText>
+          <ThemedText type="default">{eventKey}</ThemedText>
+        </View>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    gap: 16,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+});

--- a/app/screens/MatchScout/MatchScoutScreen.tsx
+++ b/app/screens/MatchScout/MatchScoutScreen.tsx
@@ -15,6 +15,7 @@ const MOCK_MATCHES: MatchScheduleEntry[] = [
   {
     match_number: 1,
     match_level: 'qm',
+    event_key: '2024mock',
     red1_id: 111,
     red2_id: 222,
     red3_id: 333,
@@ -25,6 +26,7 @@ const MOCK_MATCHES: MatchScheduleEntry[] = [
   {
     match_number: 2,
     match_level: 'qm',
+    event_key: '2024mock',
     red1_id: 777,
     red2_id: 888,
     red3_id: 999,
@@ -35,6 +37,7 @@ const MOCK_MATCHES: MatchScheduleEntry[] = [
   {
     match_number: 1,
     match_level: 'sf',
+    event_key: '2024mock',
     red1_id: 1313,
     red2_id: 1414,
     red3_id: 1515,
@@ -45,6 +48,7 @@ const MOCK_MATCHES: MatchScheduleEntry[] = [
   {
     match_number: 1,
     match_level: 'f',
+    event_key: '2024mock',
     red1_id: 1919,
     red2_id: 2020,
     red3_id: 2121,
@@ -72,6 +76,10 @@ export function MatchScoutScreen() {
           params[key] = String(value);
         }
       };
+
+      if (match.event_key) {
+        params.eventKey = match.event_key;
+      }
 
       maybeAddTeam('red1', match.red1_id);
       maybeAddTeam('red2', match.red2_id);

--- a/components/match-schedule/types.ts
+++ b/components/match-schedule/types.ts
@@ -1,6 +1,7 @@
 export interface MatchScheduleEntry {
   match_number: number;
   match_level: string;
+  event_key?: string;
   red1_id?: number | null;
   red2_id?: number | null;
   red3_id?: number | null;


### PR DESCRIPTION
## Summary
- include the event key in mock match schedule entries and propagate it through the team selection params
- replace the selection preview with a Begin Scouting button that opens a placeholder scouting screen
- add a temporary Begin Scouting route that displays the selected team, match number, and event key

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7c60f4a588326ace05347ad6a1390