### PR TITLE
Adjust begin scouting button color for red alliance

### DIFF
--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -90,6 +90,7 @@ export function MatchTeamSelectScreen({
   const neutralButtonText = useThemeColor({}, 'text');
   const headerText = useThemeColor({}, 'text');
   const primaryButtonBackground = useThemeColor({ light: '#2563EB', dark: '#1E3A8A' }, 'tint');
+  const redButtonBackground = useThemeColor({ light: '#DC2626', dark: '#7F1D1D' }, 'tint');
   const primaryButtonText = '#F8FAFC';
 
   const matchLabel = useMemo(() => {
@@ -196,7 +197,10 @@ export function MatchTeamSelectScreen({
               style={({ pressed }) => [
                 styles.beginButton,
                 {
-                  backgroundColor: primaryButtonBackground,
+                  backgroundColor:
+                    selectedOption?.alliance === 'red'
+                      ? redButtonBackground
+                      : primaryButtonBackground,
                   opacity: !canBeginScouting ? 0.5 : pressed ? 0.85 : 1,
                 },
               ]}


### PR DESCRIPTION
## Summary
- update the Match Team Select screen so the begin scouting button uses a red tint when a red alliance position is chosen
- keep the existing blue styling for blue alliance selections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7ccfd26c883269caf3a3beac552a1