### PR TITLE
Update match scouting header with dynamic title

### DIFF
--- a/app/(drawer)/match-scout/_layout.tsx
+++ b/app/(drawer)/match-scout/_layout.tsx
@@ -5,6 +5,7 @@ export default function MatchScoutLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="select-team" options={{ presentation: 'card' }} />
+      <Stack.Screen name="begin-scouting" options={{ headerShown: true, title: 'Match Scout' }} />
     </Stack>
   );
 }

--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -1,6 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+import type { ParamListBase } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
@@ -124,6 +126,7 @@ function CounterControl({ label, value, onIncrement, onDecrement }: CounterContr
 
 export default function BeginScoutingRoute() {
   const params = useLocalSearchParams<BeginScoutingParams>();
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
 
   const initialTeamNumber = toSingleValue(params.teamNumber) ?? '';
   const initialMatchNumber = toSingleValue(params.matchNumber) ?? '';
@@ -162,6 +165,11 @@ export default function BeginScoutingRoute() {
 
     return `${eventKey} ${matchLabel}: Team ${initialTeamNumber} (${driverStation})`;
   }, [driverStation, eventKey, hasPrefilledDetails, initialMatchNumber, initialTeamNumber, matchLevel]);
+
+  useEffect(() => {
+    const headerTitle = matchDetailsTitle || 'Match Scout';
+    navigation.setOptions({ headerTitle });
+  }, [navigation, matchDetailsTitle]);
 
   const handleAdjust = (key: PhaseKey, delta: 1 | -1) => {
     const limit = isAuto ? limitConfig[key].auto : limitConfig[key].teleop;

--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -51,8 +51,6 @@ const getMatchLevelLabel = (matchLevel: string | undefined) => {
 
 const renderTeamNumber = (value?: number) => (value === undefined ? 'TBD' : value);
 
-const getDriverStationLabel = (key: TeamOption['key']) => key.replace('_id', '');
-
 export interface MatchTeamSelectScreenProps {
   matchLevel?: string;
   matchNumber?: number;
@@ -123,7 +121,7 @@ export function MatchTeamSelectScreen({
     [selectedTeam, teamOptions]
   );
 
-  const driverStationLabel = selectedOption ? getDriverStationLabel(selectedOption.key) : undefined;
+  const driverStationLabel = selectedOption?.label;
 
   const handleBeginScouting = useCallback(() => {
     if (!selectedOption || selectedOption.teamNumber === undefined) {


### PR DESCRIPTION
## Summary
- show the selected alliance position label when passing the driver station to the scouting screen
- expose the begin scouting screen in the stack navigator so it can display the header
- set the begin scouting header title to the dynamic match details when available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7d722c4f08326a9a69ba56c8dbf99