### PR TITLE
feat: show match details in scouting header

### DIFF
--- a/app/(drawer)/match-scout/_layout.tsx
+++ b/app/(drawer)/match-scout/_layout.tsx
@@ -1,11 +1,65 @@
 import { Stack } from 'expo-router';
 
+type BeginScoutingRouteParams = {
+  teamNumber?: string | string[];
+  matchNumber?: string | string[];
+  eventKey?: string | string[];
+  driverStation?: string | string[];
+  matchLevel?: string | string[];
+};
+
+const toSingleValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const getMatchLevelLabel = (matchLevel: string | undefined) => {
+  const normalized = matchLevel?.toLowerCase();
+
+  switch (normalized) {
+    case 'qm':
+      return 'Quals';
+    case 'sf':
+      return 'Semis';
+    case 'qf':
+      return 'Quarters';
+    case 'f':
+      return 'Finals';
+    default:
+      return matchLevel?.toUpperCase() ?? '';
+  }
+};
+
+const buildMatchHeaderTitle = (params: BeginScoutingRouteParams) => {
+  const eventKey = toSingleValue(params.eventKey);
+  const matchNumber = toSingleValue(params.matchNumber);
+  const teamNumber = toSingleValue(params.teamNumber);
+  const driverStation = toSingleValue(params.driverStation);
+  const matchLevel = toSingleValue(params.matchLevel);
+
+  const hasPrefilledDetails = Boolean(eventKey && matchNumber && teamNumber && driverStation);
+
+  if (!hasPrefilledDetails) {
+    return 'Match Scout';
+  }
+
+  const levelLabel = getMatchLevelLabel(matchLevel);
+  const matchPrefix = levelLabel || matchLevel;
+  const matchLabel = matchPrefix ? `${matchPrefix} Match ${matchNumber}` : `Match ${matchNumber}`;
+
+  return `${eventKey} ${matchLabel}: Team ${teamNumber} (${driverStation})`;
+};
+
 export default function MatchScoutLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="select-team" options={{ presentation: 'card' }} />
-      <Stack.Screen name="begin-scouting" options={{ headerShown: true, title: 'Match Scout' }} />
+      <Stack.Screen
+        name="begin-scouting"
+        options={({ route }) => ({
+          headerShown: true,
+          title: buildMatchHeaderTitle((route.params ?? {}) as BeginScoutingRouteParams),
+        })}
+      />
     </Stack>
   );
 }

--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -144,8 +144,12 @@ export function MatchTeamSelectScreen({
       params.eventKey = eventKey;
     }
 
+    if (matchLevel) {
+      params.matchLevel = matchLevel;
+    }
+
     router.push({ pathname: '/(drawer)/match-scout/begin-scouting', params });
-  }, [driverStationLabel, eventKey, matchNumber, router, selectedOption]);
+  }, [driverStationLabel, eventKey, matchLevel, matchNumber, router, selectedOption]);
 
   const canBeginScouting = selectedOption?.teamNumber !== undefined;
 


### PR DESCRIPTION
## Summary
- compute the begin-scouting header title from the active route parameters so the match information shows in the navigation bar
- include the match level when launching the begin scouting flow to provide full context for the header label

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e7dbedc1fc8326887be68b380be930