### PR TITLE
fix: hide match scout drawer header

### DIFF
--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -18,6 +18,7 @@ export default function DrawerLayout() {
             drawerIcon: ({ color, size }: { color: string; size: number }) => (
               <Ionicons name={item.icon} size={size} color={color} />
             ),
+            ...(item.options ?? {}),
           }}
         />
       ))}

--- a/app/(drawer)/match-scout/_layout.tsx
+++ b/app/(drawer)/match-scout/_layout.tsx
@@ -1,11 +1,26 @@
 import { Stack } from 'expo-router';
 
+import { buildMatchHeaderTitle, type MatchHeaderParams } from '../../utils/match-header';
+
 export default function MatchScoutLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="select-team" options={{ presentation: 'card' }} />
-      <Stack.Screen name="begin-scouting" options={{ headerShown: true, title: 'Match Scout' }} />
+      <Stack.Screen
+        name="begin-scouting"
+        options={({ route }) => {
+          const headerTitle = buildMatchHeaderTitle(route.params as MatchHeaderParams | undefined);
+
+          return {
+            headerShown: true,
+            headerTitle,
+            headerLargeTitle: false,
+            headerBackTitleVisible: false,
+            headerBackTitle: '',
+          };
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -7,6 +7,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
 import { useThemeColor } from '@/hooks/use-theme-color';
+import { buildMatchHeaderTitle } from '../../utils/match-header';
 
 const toSingleValue = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
@@ -51,23 +52,6 @@ const createInitialPhaseCounts = (): PhaseCounts => ({
 });
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
-
-const getMatchLevelLabel = (matchLevel: string | undefined) => {
-  const normalized = matchLevel?.toLowerCase();
-
-  switch (normalized) {
-    case 'qm':
-      return 'Quals';
-    case 'sf':
-      return 'Semis';
-    case 'qf':
-      return 'Quarters';
-    case 'f':
-      return 'Finals';
-    default:
-      return matchLevel?.toUpperCase() ?? '';
-  }
-};
 
 interface CounterControlProps {
   label: string;
@@ -152,23 +136,28 @@ export default function BeginScoutingRoute() {
     () => Boolean(eventKey && initialMatchNumber && initialTeamNumber && driverStation),
     [driverStation, eventKey, initialMatchNumber, initialTeamNumber]
   );
-  const matchDetailsTitle = useMemo(() => {
-    if (!hasPrefilledDetails) {
-      return '';
-    }
-
-    const levelLabel = getMatchLevelLabel(matchLevel);
-    const matchPrefix = levelLabel || matchLevel;
-    const matchLabel = matchPrefix
-      ? `${matchPrefix} Match ${initialMatchNumber}`
-      : `Match ${initialMatchNumber}`;
-
-    return `${eventKey} ${matchLabel}: Team ${initialTeamNumber} (${driverStation})`;
-  }, [driverStation, eventKey, hasPrefilledDetails, initialMatchNumber, initialTeamNumber, matchLevel]);
+  const matchDetailsTitle = useMemo(
+    () =>
+      hasPrefilledDetails
+        ? buildMatchHeaderTitle({
+            driverStation,
+            eventKey,
+            matchLevel,
+            matchNumber: initialMatchNumber,
+            teamNumber: initialTeamNumber,
+          })
+        : '',
+    [driverStation, eventKey, hasPrefilledDetails, initialMatchNumber, initialTeamNumber, matchLevel]
+  );
 
   useEffect(() => {
-    const headerTitle = matchDetailsTitle || 'Match Scout';
-    navigation.setOptions({ headerTitle, title: headerTitle });
+    const headerTitle = matchDetailsTitle;
+    navigation.setOptions({
+      headerTitle,
+      headerLargeTitle: false,
+      headerBackTitleVisible: false,
+      headerBackTitle: '',
+    });
   }, [navigation, matchDetailsTitle]);
 
   const handleAdjust = (key: PhaseKey, delta: 1 | -1) => {

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -1,5 +1,6 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import type { ComponentProps } from 'react';
+import type { DrawerNavigationOptions } from '@react-navigation/drawer';
 
 import { Colors } from '@/constants/theme';
 import { ROUTES } from '@/constants/routes';
@@ -12,9 +13,18 @@ export const DRAWER_ITEMS: {
   title: string;
   href: string;
   icon: IoniconName;
+  options?: DrawerNavigationOptions;
 }[] = [
   { name: 'pit-scout/index', title: 'Pit Scout', href: ROUTES.pitScout, icon: 'build-outline' },
-  { name: 'match-scout/index', title: 'Match Scout', href: ROUTES.matchScout, icon: 'trophy-outline' },
+  {
+    name: 'match-scout/index',
+    title: 'Match Scout',
+    href: ROUTES.matchScout,
+    icon: 'trophy-outline',
+    options: {
+      headerShown: false,
+    },
+  },
   { name: 'settings/index', title: 'App Settings', href: ROUTES.appSettings, icon: 'settings-outline' },
   {
     name: 'user-settings/index',

--- a/app/screens/MatchScout/MatchTeamSelectScreen.tsx
+++ b/app/screens/MatchScout/MatchTeamSelectScreen.tsx
@@ -133,7 +133,7 @@ export function MatchTeamSelectScreen({
     };
 
     if (driverStationLabel) {
-      params.driverStation = driverStationLabel;
+      params.driverStation = driverStationLabel.toUpperCase();
     }
 
     if (matchNumber !== undefined) {
@@ -144,8 +144,12 @@ export function MatchTeamSelectScreen({
       params.eventKey = eventKey;
     }
 
+    if (matchLevel) {
+      params.matchLevel = matchLevel;
+    }
+
     router.push({ pathname: '/(drawer)/match-scout/begin-scouting', params });
-  }, [driverStationLabel, eventKey, matchNumber, router, selectedOption]);
+  }, [driverStationLabel, eventKey, matchLevel, matchNumber, router, selectedOption]);
 
   const canBeginScouting = selectedOption?.teamNumber !== undefined;
 

--- a/app/utils/match-header.ts
+++ b/app/utils/match-header.ts
@@ -1,0 +1,53 @@
+export type MatchHeaderParams = {
+  teamNumber?: string | string[];
+  matchNumber?: string | string[];
+  eventKey?: string | string[];
+  driverStation?: string | string[];
+  matchLevel?: string | string[];
+};
+
+const toSingleValue = (value: string | string[] | undefined) =>
+  Array.isArray(value) ? value[0] : value;
+
+const normalize = (value?: string) => value?.trim();
+
+const getMatchLevelLabel = (matchLevel: string | undefined) => {
+  const normalized = matchLevel?.toLowerCase();
+
+  switch (normalized) {
+    case 'qm':
+      return 'QUALS';
+    case 'sf':
+      return 'SEMIS';
+    case 'qf':
+      return 'QUARTERS';
+    case 'f':
+      return 'FINALS';
+    default:
+      return matchLevel?.toUpperCase() ?? '';
+  }
+};
+
+export const buildMatchHeaderTitle = (rawParams: MatchHeaderParams | undefined) => {
+  if (!rawParams) {
+    return '';
+  }
+
+  const eventKey = normalize(toSingleValue(rawParams.eventKey));
+  const matchNumber = normalize(toSingleValue(rawParams.matchNumber));
+  const teamNumber = normalize(toSingleValue(rawParams.teamNumber));
+  const driverStation = normalize(toSingleValue(rawParams.driverStation));
+  const matchLevel = normalize(toSingleValue(rawParams.matchLevel));
+
+  const hasAllDetails = Boolean(eventKey && matchNumber && teamNumber && driverStation);
+
+  if (!hasAllDetails) {
+    return '';
+  }
+
+  const levelLabel = getMatchLevelLabel(matchLevel);
+  const matchLabel = levelLabel ? `${levelLabel} MATCH ${matchNumber}` : `MATCH ${matchNumber}`;
+  const driverStationLabel = driverStation.toUpperCase();
+
+  return `${eventKey.toUpperCase()} ${matchLabel}: TEAM ${teamNumber} (${driverStationLabel})`;
+};


### PR DESCRIPTION
## Summary
- hide the drawer-provided header for the match scout stack so only the match details header is shown
- allow drawer items to specify custom navigation options that are merged into the drawer layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7dbedc1fc8326887be68b380be930