### PR TITLE
Improve drawer tab highlighting in dark mode

### DIFF
--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -27,6 +27,10 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
   const colorScheme = useColorScheme();
   const activeRouteName = state.routes[state.index]?.name;
   const tint = Colors[colorScheme ?? 'light'].tint;
+  const inactiveIconColor = Colors[colorScheme ?? 'light'].icon;
+  const activeItemBackground =
+    colorScheme === 'dark' ? 'rgba(255, 255, 255, 0.08)' : '#e6f6fb';
+  const dividerColor = colorScheme === 'dark' ? '#2f3133' : '#d0d0d0';
 
   const handleAuthAction = () => {
     navigation.closeDrawer();
@@ -60,9 +64,16 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
                 router.navigate(item.href);
                 navigation.closeDrawer();
               }}
-              style={[styles.drawerItem, isActive && styles.drawerItemActive]}
+              style={[
+                styles.drawerItem,
+                isActive && { backgroundColor: activeItemBackground },
+              ]}
             >
-              <Ionicons name={item.icon} size={20} color={isActive ? tint : '#687076'} />
+              <Ionicons
+                name={item.icon}
+                size={20}
+                color={isActive ? tint : inactiveIconColor}
+              />
               <ThemedText type={isActive ? 'defaultSemiBold' : 'default'}>{item.title}</ThemedText>
             </Pressable>
           );
@@ -71,7 +82,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
       <Pressable
         accessibilityRole="button"
         onPress={handleAuthAction}
-        style={styles.authButton}
+        style={[styles.authButton, { borderTopColor: dividerColor }]}
       >
         <Ionicons
           name={isAuthenticated ? 'log-out-outline' : 'log-in-outline'}
@@ -107,9 +118,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginBottom: 4,
   },
-  drawerItemActive: {
-    backgroundColor: '#e6f6fb',
-  },
   authButton: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -117,6 +125,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 16,
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: '#d0d0d0',
   },
 });


### PR DESCRIPTION
## Summary
- adjust drawer item styling to use theme-aware active backgrounds
- ensure inactive icons and divider colors respect the current color scheme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7fe5fd8188326967a38f230789dca