### PR TITLE
Add pit scout team details screen

### DIFF
--- a/app/(drawer)/pit-scout/_layout.tsx
+++ b/app/(drawer)/pit-scout/_layout.tsx
@@ -1,0 +1,15 @@
+import { Stack } from 'expo-router';
+
+export default function PitScoutLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: 'Pit Scout' }} />
+      <Stack.Screen
+        name="team-details"
+        options={{
+          headerBackTitle: 'Back',
+        }}
+      />
+    </Stack>
+  );
+}

--- a/app/(drawer)/pit-scout/team-details.tsx
+++ b/app/(drawer)/pit-scout/team-details.tsx
@@ -1,0 +1,68 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export default function PitScoutTeamDetailsScreen() {
+  const params = useLocalSearchParams<{ teamNumber?: string | string[]; teamName?: string | string[] }>();
+
+  const teamNumber = Array.isArray(params.teamNumber) ? params.teamNumber[0] : params.teamNumber;
+  const teamName = Array.isArray(params.teamName) ? params.teamName[0] : params.teamName;
+
+  const headerTitle = [teamNumber, teamName].filter(Boolean).join(' - ') || 'Team';
+
+  const primaryButtonBackground = useThemeColor({ light: '#2563EB', dark: '#1E3A8A' }, 'tint');
+  const primaryButtonText = '#F8FAFC';
+  const footerBackground = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
+  const borderColor = useThemeColor({ light: 'rgba(15, 23, 42, 0.08)', dark: 'rgba(148, 163, 184, 0.25)' }, 'text');
+
+  return (
+    <ScreenContainer>
+      <Stack.Screen options={{ title: headerTitle }} />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.flexSpacer} />
+        <View style={[styles.footer, { backgroundColor: footerBackground, borderColor }]}>
+          <Pressable
+            accessibilityRole="button"
+            style={({ pressed }) => [
+              styles.submitButton,
+              {
+                backgroundColor: primaryButtonBackground,
+                opacity: pressed ? 0.9 : 1,
+              },
+            ]}
+          >
+            <ThemedText type="defaultSemiBold" style={[styles.submitButtonText, { color: primaryButtonText }]}>
+              Submit Pit Data
+            </ThemedText>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    flexGrow: 1,
+    padding: 24,
+  },
+  flexSpacer: {
+    flex: 1,
+  },
+  footer: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+  },
+  submitButton: {
+    alignItems: 'center',
+    borderRadius: 12,
+    paddingVertical: 14,
+  },
+  submitButtonText: {
+    fontSize: 18,
+  },
+});

--- a/app/screens/PitScout/PitScoutScreen.tsx
+++ b/app/screens/PitScout/PitScoutScreen.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, TextInput, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
 import { useThemeColor } from '@/hooks/use-theme-color';
+import { useRouter } from 'expo-router';
 
 interface TeamListItem {
   number: number;
@@ -31,6 +32,7 @@ const normalizeText = (value: string) => value.normalize('NFD').replace(/[\u0300
 
 export function PitScoutScreen() {
   const [searchTerm, setSearchTerm] = useState('');
+  const router = useRouter();
 
   const backgroundCard = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
   const searchBackground = useThemeColor({ light: '#F1F5F9', dark: '#1F2937' }, 'background');
@@ -67,6 +69,16 @@ export function PitScoutScreen() {
     });
   }, [searchTerm]);
 
+  const handleTeamPress = (team: TeamListItem) => {
+    router.push({
+      pathname: '/(drawer)/pit-scout/team-details',
+      params: {
+        teamNumber: String(team.number),
+        teamName: team.name,
+      },
+    });
+  };
+
   return (
     <ScreenContainer>
       <ScrollView
@@ -89,7 +101,19 @@ export function PitScoutScreen() {
 
         <View style={styles.listContainer}>
           {filteredTeams.map((team) => (
-            <View key={team.number} style={[styles.teamRow, { backgroundColor: backgroundCard, borderColor }]}>
+            <Pressable
+              key={team.number}
+              accessibilityRole="button"
+              onPress={() => handleTeamPress(team)}
+              style={({ pressed }) => [
+                styles.teamRow,
+                {
+                  backgroundColor: backgroundCard,
+                  borderColor,
+                  opacity: pressed ? 0.95 : 1,
+                },
+              ]}
+            >
               <ThemedText type="defaultSemiBold" style={styles.teamNumber}>
                 {team.number}
               </ThemedText>
@@ -101,7 +125,7 @@ export function PitScoutScreen() {
                   {team.location}
                 </ThemedText>
               </View>
-            </View>
+            </Pressable>
           ))}
         </View>
       </ScrollView>


### PR DESCRIPTION
## Summary
- allow selecting a pit scouting team to open a dedicated team details screen from the drawer
- add a placeholder team details view with a submit button and custom header title

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e803895dbc8326b0ab8a61fb151b5d