### PR TITLE
Redirect pit scout submit to index

### DIFF
--- a/app/(drawer)/pit-scout/team-details.tsx
+++ b/app/(drawer)/pit-scout/team-details.tsx
@@ -1,4 +1,4 @@
-import { Stack, useLocalSearchParams } from 'expo-router';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
@@ -7,6 +7,7 @@ import { useThemeColor } from '@/hooks/use-theme-color';
 
 export default function PitScoutTeamDetailsScreen() {
   const params = useLocalSearchParams<{ teamNumber?: string | string[]; teamName?: string | string[] }>();
+  const router = useRouter();
 
   const teamNumber = Array.isArray(params.teamNumber) ? params.teamNumber[0] : params.teamNumber;
   const teamName = Array.isArray(params.teamName) ? params.teamName[0] : params.teamName;
@@ -26,6 +27,9 @@ export default function PitScoutTeamDetailsScreen() {
         <View style={[styles.footer, { backgroundColor: footerBackground, borderColor }]}>
           <Pressable
             accessibilityRole="button"
+            onPress={() => {
+              router.replace('/(drawer)/pit-scout');
+            }}
             style={({ pressed }) => [
               styles.submitButton,
               {


### PR DESCRIPTION
## Summary
- add router usage to the pit scout team details screen
- redirect the submit button back to the pit scout index route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e80579cf688326b0e217322e13db80