### PR TITLE
Ensure Pit Scout screen displays proper title

### DIFF
--- a/app/screens/PitScout/PitScoutScreen.tsx
+++ b/app/screens/PitScout/PitScoutScreen.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, TextInput, View } from 'react-native';
 
+import { Stack } from 'expo-router';
+
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
 import { useThemeColor } from '@/hooks/use-theme-color';
@@ -81,6 +83,7 @@ export function PitScoutScreen() {
 
   return (
     <ScreenContainer>
+      <Stack.Screen options={{ title: 'Pit Scout' }} />
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Summary
- set the Pit Scout screen's stack title to "Pit Scout" so the header no longer shows the hyphenated slug

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e80f2493e48326a834170665ec6639