### PR TITLE
feat: show toast after general data update

### DIFF
--- a/app/screens/Settings/AppSettingsScreen.tsx
+++ b/app/screens/Settings/AppSettingsScreen.tsx
@@ -6,6 +6,7 @@ import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
 import { updateGeneralData, type UpdateGeneralDataResult } from '../../services/general-data';
 import { pingBackend } from '../../services/api/ping';
+import { showToast } from '../../utils/showToast';
 
 export function AppSettingsScreen() {
   const [lastResult, setLastResult] = useState<UpdateGeneralDataResult | null>(null);
@@ -27,11 +28,9 @@ export function AppSettingsScreen() {
     updateGeneralDataMutation.mutate(undefined, {
       onSuccess: (result) => {
         setLastResult(result);
-
-        Alert.alert(
-          'General data updated',
-          `Teams updated: ${result.teams.created + result.teams.updated}. Events updated: ${result.events.created + result.events.updated}.`
-        );
+        const addedTeamsCount = result.teams.created;
+        const teamLabel = addedTeamsCount === 1 ? 'team' : 'teams';
+        showToast(`Added ${addedTeamsCount} new ${teamLabel}.`);
       },
       onError: (error) => {
         console.error('Failed to update general data', error);

--- a/app/utils/showToast.ts
+++ b/app/utils/showToast.ts
@@ -1,0 +1,11 @@
+import { Alert, Platform, ToastAndroid } from 'react-native';
+
+export function showToast(message: string, title = 'General data updated') {
+  const show = Platform.select<() => void>({
+    android: () => ToastAndroid.show(message, ToastAndroid.SHORT),
+    ios: () => Alert.alert(title, message),
+    default: () => Alert.alert(title, message),
+  });
+
+  show?.();
+}


### PR DESCRIPTION
## Summary
- add a toast helper that uses the native toast on Android and an alert fallback elsewhere
- show the number of newly created teams in a toast after updating general data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e819521b5083269e77b99974405f58