### PR TITLE
Wrap navigation root with auth provider

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,18 +16,18 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <QueryProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <OrganizationProvider>
-          <AuthProvider>
+    <AuthProvider>
+      <QueryProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <OrganizationProvider>
             <Stack screenOptions={{ headerShown: false }}>
               <Stack.Screen name="(drawer)" />
               <Stack.Screen name="auth/login" />
             </Stack>
             <StatusBar style="auto" />
-          </AuthProvider>
-        </OrganizationProvider>
-      </ThemeProvider>
-    </QueryProvider>
+          </OrganizationProvider>
+        </ThemeProvider>
+      </QueryProvider>
+    </AuthProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the app's navigation stack with the AuthProvider so drawer content can consume authentication state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee50e84eb4832689b53d348218d9c2