### PR TITLE
Integrate Supabase login flow into router

### DIFF
--- a/app/screens/Auth/LoginScreen.tsx
+++ b/app/screens/Auth/LoginScreen.tsx
@@ -1,39 +1,13 @@
-import { useCallback, useState } from 'react';
-import { Button, StyleSheet, TextInput } from 'react-native';
-
-import { ScreenContainer } from '@/components/layout/ScreenContainer';
-import { ThemedText } from '@/components/themed-text';
 import { useAuth } from '@/hooks/use-authentication';
-import { useOrganization } from '@/hooks/use-organization';
+
+import SupabaseLoginScreen from '@/src/screens/LoginScreen';
 
 export function LoginScreen() {
-  const { login, isAuthenticated } = useAuth();
-  const { setSelectedOrganization } = useOrganization();
-  const [organizationHint] = useState('OAuth Provider');
+  const { isAuthenticated } = useAuth();
 
-  const handleLogin = useCallback(() => {
-    setSelectedOrganization('Team 2471');
-    login();
-  }, [login, setSelectedOrganization]);
+  if (isAuthenticated) {
+    return null;
+  }
 
-  return (
-    <ScreenContainer>
-      <ThemedText type="title">Sign in</ThemedText>
-      <ThemedText>
-        Authentication is handled through OAuth. Tap the button below to start a mock OAuth flow and personalize the
-        scouting tools, or continue exploring as a guest from the drawer menu.
-      </ThemedText>
-      <TextInput editable={false} style={styles.input} value={`Provider: ${organizationHint}`} />
-      <Button title={isAuthenticated ? 'Continue' : 'Sign in with OAuth'} onPress={handleLogin} />
-    </ScreenContainer>
-  );
+  return <SupabaseLoginScreen />;
 }
-
-const styles = StyleSheet.create({
-  input: {
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#999',
-    padding: 12,
-  },
-});

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,12 +1,20 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
-import { createContext } from 'react';
 import * as Linking from 'expo-linking';
 import Constants from 'expo-constants';
 import * as SecureStore from 'expo-secure-store';
 import type { Session, User } from '@supabase/supabase-js';
 
-import supabase from '../supabaseClient';
+import { supabase } from '../supabaseClient';
 
 const SESSION_KEY = 'supabase.session';
 const REFRESH_TOKEN_KEY = 'supabase.refresh_token';
@@ -229,7 +237,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [isLoading, isSigningIn, session, signInWithDiscord, signOut, user]
   );
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return createElement(AuthContext.Provider, { value }, children);
 }
 
 export function useAuth(): AuthContextValue {


### PR DESCRIPTION
## Summary
- wrap the Expo Router auth provider with the Supabase auth provider and expose loading/auth helpers
- replace the mock OAuth login screen with the Supabase Discord login screen used in the src tree
- convert the Supabase auth hook to TSX and clean up its React imports for linting compatibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee542dea748326b9052f074f3f17e5