### PR TITLE
fix: align secure store adapter with supabase

### DIFF
--- a/src/utils/ExpoSecureStoreAdapter.ts
+++ b/src/utils/ExpoSecureStoreAdapter.ts
@@ -1,12 +1,7 @@
+import type { SupportedStorage } from '@supabase/auth-js';
 import * as SecureStore from 'expo-secure-store';
 
-export interface AsyncStorageLike {
-  getItem(key: string): Promise<string | null>;
-  setItem(key: string, value: string): Promise<void>;
-  removeItem(key: string): Promise<void>;
-}
-
-const ExpoSecureStoreAdapter: AsyncStorageLike = {
+const ExpoSecureStoreAdapter: SupportedStorage = {
   async getItem(key) {
     try {
       return await SecureStore.getItemAsync(key);


### PR DESCRIPTION
## Summary
- type the secure store adapter using Supabase's SupportedStorage interface
- rely on expo-secure-store's getItemAsync, setItemAsync, and deleteItemAsync implementations for compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee628b25ec8326a8cc0d4f4f0d0a0e