### PR TITLE
fix: use expo secure store item methods

### DIFF
--- a/src/utils/ExpoSecureStoreAdapter.ts
+++ b/src/utils/ExpoSecureStoreAdapter.ts
@@ -1,10 +1,14 @@
 import type { SupportedStorage } from '@supabase/auth-js';
-import * as SecureStore from 'expo-secure-store';
+import {
+  deleteItemAsync,
+  getItemAsync,
+  setItemAsync,
+} from 'expo-secure-store';
 
 const ExpoSecureStoreAdapter: SupportedStorage = {
   async getItem(key) {
     try {
-      return await SecureStore.getItemAsync(key);
+      return await getItemAsync(key);
     } catch (error) {
       console.warn(`[SecureStore] Failed to read key "${key}":`, error);
       return null;
@@ -12,14 +16,14 @@ const ExpoSecureStoreAdapter: SupportedStorage = {
   },
   async setItem(key, value) {
     try {
-      await SecureStore.setItemAsync(key, value);
+      await setItemAsync(key, value);
     } catch (error) {
       console.warn(`[SecureStore] Failed to write key "${key}":`, error);
     }
   },
   async removeItem(key) {
     try {
-      await SecureStore.deleteItemAsync(key);
+      await deleteItemAsync(key);
     } catch (error) {
       console.warn(`[SecureStore] Failed to delete key "${key}":`, error);
     }


### PR DESCRIPTION
## Summary
- update the SecureStore adapter to rely on expo-secure-store's getItemAsync, setItemAsync, and deleteItemAsync helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee63f5aecc8326828a975525d95496