### PR TITLE
fix: normalize secure store export in root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,4 @@
+import * as SecureStore from 'expo-secure-store';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -5,8 +6,18 @@ import 'react-native-reanimated';
 
 import '@/db'; // Initialize the SQLite-backed storage on startup.
 
-import { AuthProvider, OrganizationProvider, QueryProvider } from '@/app/providers';
-import { useColorScheme } from '@/hooks/use-color-scheme';
+// Normalize the export shape expected by @supabase/auth-js when running in Expo.
+// The library reaches for ExpoSecureStore.default, but the package only exposes
+// named exports in ESM environments. Assigning the module object to its own
+// default export ensures both patterns resolve to the same implementation.
+(SecureStore as typeof SecureStore & { default?: typeof SecureStore }).default ??= SecureStore;
+
+type ProvidersModule = typeof import('@/app/providers');
+const { AuthProvider, OrganizationProvider, QueryProvider } =
+  require('@/app/providers') as ProvidersModule;
+
+type UseColorSchemeModule = typeof import('@/hooks/use-color-scheme');
+const { useColorScheme } = require('@/hooks/use-color-scheme') as UseColorSchemeModule;
 
 export const unstable_settings = {
   initialRouteName: '(drawer)',


### PR DESCRIPTION
## Summary
- remove the redundant App.tsx shim and patch expo-secure-store from the Expo Router entry
- ensure Supabase sees a default export on expo-secure-store before providers load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee65e28d188326af52ab04a52b19bc