### PR TITLE
Auto refresh Supabase sessions before expiration

### DIFF
--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -1,3 +1,4 @@
 export * from './base';
 export * from './client';
 export * from './ping';
+export * from './user';

--- a/app/services/api/user.ts
+++ b/app/services/api/user.ts
@@ -1,0 +1,10 @@
+import { apiRequest } from './client';
+
+export interface UserInfoResponse {
+  display_name: string | null;
+  [key: string]: unknown;
+}
+
+export const getUserInfo = async () => {
+  return await apiRequest<UserInfoResponse>('/user/info');
+};

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -5,13 +5,26 @@ import * as WebBrowser from 'expo-web-browser'; // ✅ needed for Expo Go
 WebBrowser.maybeCompleteAuthSession();
 
 // eslint-disable-next-line import/first
-import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 // eslint-disable-next-line import/first
 import { supabase } from '../lib/supabase';
+
+// eslint-disable-next-line import/first
+import { getUserInfo, setAuthorizationToken } from '@/app/services/api';
 
 
 const SESSION_KEY = 'supabase.session';
 const REFRESH_TOKEN_KEY = 'supabase.refresh_token';
+const REFRESH_THRESHOLD_MS = 10 * 60 * 1000;
 
 type AuthContextValue = {
   user: User | null;
@@ -19,16 +32,20 @@ type AuthContextValue = {
   isLoading: boolean;
   signInWithDiscord: () => Promise<void>;
   signOut: () => Promise<void>;
+  displayName: string | null;
+  refreshUserInfo: () => Promise<void>;
+  isFetchingUserInfo: boolean;
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-async function persistSession(session: Session | null) {
+async function persistSession(session: Session | null, refreshTokenOverride?: string) {
   try {
     if (session) {
       await SecureStore.setItemAsync(SESSION_KEY, JSON.stringify(session));
-      if (session.refresh_token) {
-        await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, session.refresh_token);
+      const refreshTokenToStore = refreshTokenOverride ?? session.refresh_token;
+      if (refreshTokenToStore) {
+        await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshTokenToStore);
       }
     } else {
       await SecureStore.deleteItemAsync(SESSION_KEY);
@@ -37,6 +54,11 @@ async function persistSession(session: Session | null) {
   } catch (error) {
     console.warn('Failed to persist Supabase session:', error);
   }
+}
+
+async function persistSessionWithFallback(session: Session) {
+  const storedRefresh = session.refresh_token ?? (await SecureStore.getItemAsync(REFRESH_TOKEN_KEY));
+  await persistSession(session, storedRefresh ?? undefined);
 }
 
 async function restoreSession() {
@@ -50,8 +72,9 @@ async function restoreSession() {
       access_token: parsed.access_token,
       refresh_token: storedRefresh,
     });
-    if (error) return null;
-    return data.session;
+    if (error || !data.session) return null;
+    const refreshToken = data.session.refresh_token ?? storedRefresh;
+    return { session: data.session, refreshToken };
   } catch {
     return null;
   }
@@ -61,6 +84,92 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [displayName, setDisplayName] = useState<string | null>(null);
+  const [isFetchingUserInfo, setIsFetchingUserInfo] = useState(false);
+  const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isRefreshingRef = useRef(false);
+
+  const clearRefreshTimeout = useCallback(() => {
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = null;
+    }
+  }, []);
+
+  const refreshUserInfo = useCallback(async () => {
+    if (!session?.access_token) {
+      setDisplayName(null);
+      return;
+    }
+
+    setIsFetchingUserInfo(true);
+    try {
+      const info = await getUserInfo();
+      setDisplayName(info.display_name ?? null);
+    } catch (error) {
+      console.warn('Failed to fetch user info:', error);
+    } finally {
+      setIsFetchingUserInfo(false);
+    }
+  }, [session?.access_token]);
+
+  const refreshSession = useCallback(async () => {
+    if (!session || isRefreshingRef.current) {
+      return;
+    }
+
+    isRefreshingRef.current = true;
+    try {
+      const storedRefresh = session.refresh_token ?? (await SecureStore.getItemAsync(REFRESH_TOKEN_KEY));
+      if (!storedRefresh) {
+        return;
+      }
+
+      const { data, error } = await supabase.auth.refreshSession({ refresh_token: storedRefresh });
+
+      if (error || !data.session) {
+        throw error ?? new Error('Unable to refresh session');
+      }
+
+      const nextRefreshToken = data.session.refresh_token ?? storedRefresh;
+      await persistSession(data.session, nextRefreshToken);
+      setSession(data.session);
+      setUser(data.session.user);
+    } catch (error) {
+      console.warn('Failed to refresh Supabase session:', error);
+      clearRefreshTimeout();
+      await persistSession(null);
+      setSession(null);
+      setUser(null);
+      setDisplayName(null);
+    } finally {
+      isRefreshingRef.current = false;
+    }
+  }, [clearRefreshTimeout, session]);
+
+  const scheduleSessionRefresh = useCallback(
+    (currentSession: Session | null) => {
+      clearRefreshTimeout();
+
+      if (!currentSession?.expires_at) {
+        return;
+      }
+
+      const expiresAtMs = currentSession.expires_at * 1000;
+      const refreshAt = expiresAtMs - REFRESH_THRESHOLD_MS;
+      const delay = refreshAt - Date.now();
+
+      if (delay <= 0) {
+        void refreshSession();
+        return;
+      }
+
+      refreshTimeoutRef.current = setTimeout(() => {
+        void refreshSession();
+      }, delay);
+    },
+    [clearRefreshTimeout, refreshSession],
+  );
 
   // Handle deep link callback (OAuth redirect)
   const handleUrl = useCallback(async ({ url }: { url: string }) => {
@@ -70,7 +179,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const code = String(parsed.queryParams.code);
     const { data, error } = await supabase.auth.exchangeCodeForSession({ code });
     if (!error && data.session) {
-      await persistSession(data.session);
+      await persistSessionWithFallback(data.session);
       setSession(data.session);
       setUser(data.session.user);
     }
@@ -84,12 +193,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (data.session) {
         setSession(data.session);
         setUser(data.session.user);
-        await persistSession(data.session);
+        await persistSessionWithFallback(data.session);
       } else {
         const restored = await restoreSession();
         if (restored) {
-          setSession(restored);
-          setUser(restored.user);
+          setSession(restored.session);
+          setUser(restored.session.user);
+          await persistSession(restored.session, restored.refreshToken);
         }
       }
       setIsLoading(false);
@@ -99,7 +209,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const { data: sub } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       setSession(nextSession);
       setUser(nextSession?.user ?? null);
-      persistSession(nextSession);
+      if (nextSession) {
+        void persistSessionWithFallback(nextSession);
+      } else {
+        void persistSession(null);
+      }
     });
 
     const listener = Linking.addEventListener('url', handleUrl);
@@ -110,6 +224,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       listener.remove();
     };
   }, [handleUrl]);
+
+  useEffect(() => {
+    setAuthorizationToken(session?.access_token);
+
+    if (!session?.access_token) {
+      setDisplayName(null);
+      return;
+    }
+
+    refreshUserInfo();
+  }, [session?.access_token, refreshUserInfo]);
+
+  useEffect(() => {
+    scheduleSessionRefresh(session);
+
+    return () => {
+      clearRefreshTimeout();
+    };
+  }, [clearRefreshTimeout, scheduleSessionRefresh, session]);
 
   // ✅ Discord OAuth flow (Expo Go compatible)
   const signInWithDiscord = useCallback(async () => {
@@ -135,15 +268,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await supabase.auth.signOut();
     } finally {
+      clearRefreshTimeout();
       await persistSession(null);
       setSession(null);
       setUser(null);
+      setDisplayName(null);
     }
-  }, []);
+  }, [clearRefreshTimeout]);
 
   const value = useMemo(
-    () => ({ user, session, isLoading, signInWithDiscord, signOut }),
-    [user, session, isLoading, signInWithDiscord, signOut]
+    () => ({
+      user,
+      session,
+      isLoading,
+      signInWithDiscord,
+      signOut,
+      displayName,
+      refreshUserInfo,
+      isFetchingUserInfo,
+    }),
+    [
+      user,
+      session,
+      isLoading,
+      signInWithDiscord,
+      signOut,
+      displayName,
+      refreshUserInfo,
+      isFetchingUserInfo,
+    ]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -4,7 +4,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-nati
 import { useAuth } from '../hooks/useAuth';
 
 const LoginScreen = () => {
-  const { signInWithDiscord, isLoading } = useAuth();
+  const { signInWithDiscord, isLoading, displayName } = useAuth();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -44,6 +44,10 @@ const LoginScreen = () => {
           <Text style={styles.buttonLabel}>Sign in with Discord</Text>
         )}
       </Pressable>
+
+      {displayName ? (
+        <Text style={styles.userInfo}>Session display name: {displayName}</Text>
+      ) : null}
 
       {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
     </View>
@@ -94,5 +98,11 @@ const styles = StyleSheet.create({
     color: '#ff8a80',
     marginTop: 16,
     textAlign: 'center',
+  },
+  userInfo: {
+    color: '#c6f6d5',
+    marginTop: 16,
+    textAlign: 'center',
+    fontWeight: '500',
   },
 });


### PR DESCRIPTION
## Summary
- persist Supabase refresh tokens when storing sessions and reuse them when restoring auth state
- schedule refreshes ten minutes before session expiration and gracefully handle refresh failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee805e52ec832696257fdd3e8480b9