### PR TITLE
Show authenticated display name in drawer

### DIFF
--- a/app/providers/AuthProvider.tsx
+++ b/app/providers/AuthProvider.tsx
@@ -10,6 +10,7 @@ interface AuthContextValue {
   isLoading: boolean;
   login: () => Promise<void>;
   logout: () => Promise<void>;
+  displayName: string | null;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -19,7 +20,7 @@ interface AuthProviderProps {
 }
 
 function AuthContextBridge({ children }: AuthProviderProps) {
-  const { user, isLoading, signInWithDiscord, signOut } = useSupabaseAuth();
+  const { user, isLoading, signInWithDiscord, signOut, displayName } = useSupabaseAuth();
 
   const login = useCallback(async () => {
     await signInWithDiscord();
@@ -35,8 +36,9 @@ function AuthContextBridge({ children }: AuthProviderProps) {
       isLoading,
       login,
       logout,
+      displayName,
     }),
-    [isLoading, login, logout, user],
+    [displayName, isLoading, login, logout, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -22,7 +22,7 @@ export type DrawerContentProps = {
 };
 
 export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
-  const { isAuthenticated, logout } = useAuth();
+  const { isAuthenticated, logout, displayName } = useAuth();
   const { selectedOrganization, setSelectedOrganization } = useOrganization();
   const colorScheme = useColorScheme();
   const activeRouteName = state.routes[state.index]?.name;
@@ -42,15 +42,16 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
     }
   };
 
+  const browsingLabel = `Browsing as ${displayName ?? 'guest'}`;
+  const subtitle = isAuthenticated
+    ? selectedOrganization ?? browsingLabel
+    : browsingLabel;
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <ThemedText type="title">Scouting App</ThemedText>
-        <ThemedText type="subtitle">
-          {isAuthenticated
-            ? selectedOrganization ?? 'No organization selected'
-            : 'Browsing as guest'}
-        </ThemedText>
+        <ThemedText type="subtitle">{subtitle}</ThemedText>
       </View>
       <View style={styles.content}>
         {DRAWER_ITEMS.map((item) => {


### PR DESCRIPTION
## Summary
- expose the Supabase user display name through the shared auth context
- show the authenticated display name in the drawer subtitle when no organization is selected

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee8cb3cf208326a23db39492dd1a1b