### PR TITLE
Show display name in drawer header

### DIFF
--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -16,7 +16,7 @@ const HomeScreen = () => (
 );
 
 const DrawerNavigator = () => {
-  const { user, signOut, isLoading } = useAuth();
+  const { user, signOut, isLoading, displayName, isFetchingUserInfo } = useAuth();
 
   return (
     <Drawer.Navigator
@@ -25,6 +25,21 @@ const DrawerNavigator = () => {
       }}
       drawerContent={(props) => (
         <DrawerContentScrollView {...props}>
+          <View style={styles.profileContainer}>
+            {user ? (
+              <>
+                <Text style={styles.profileHeading}>Signed in as</Text>
+                <Text style={styles.profileName}>
+                  {displayName?.trim() || user.email || 'Unknown user'}
+                </Text>
+                {isFetchingUserInfo ? (
+                  <Text style={styles.profileStatus}>Refreshing account details…</Text>
+                ) : null}
+              </>
+            ) : (
+              <Text style={styles.profileHeading}>You are browsing as a guest.</Text>
+            )}
+          </View>
           <DrawerItemList {...props} />
           {user ? (
             <DrawerItem
@@ -77,5 +92,26 @@ const styles = StyleSheet.create({
   homeCopy: {
     fontSize: 16,
     color: '#4a4a4a',
+  },
+  profileContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomColor: '#ececec',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    marginBottom: 8,
+    gap: 4,
+  },
+  profileHeading: {
+    fontSize: 14,
+    color: '#555',
+  },
+  profileName: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111',
+  },
+  profileStatus: {
+    fontSize: 12,
+    color: '#888',
   },
 });


### PR DESCRIPTION
## Summary
- render a profile header in the drawer that shows the signed-in user's display name
- show a guest message and loading indicator fallback when user info is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee9e7f7700832697c986f097502565