### PR TITLE
Add logged in event table and helpers

### DIFF
--- a/app/services/logged-in-event.ts
+++ b/app/services/logged-in-event.ts
@@ -1,0 +1,54 @@
+import { getDbOrThrow, schema } from '@/db';
+import { eq } from 'drizzle-orm';
+
+const SINGLETON_ID = 1;
+
+export function getActiveEvent(): string | null {
+  const db = getDbOrThrow();
+
+  const record = db
+    .select({ event: schema.loggedInEvents.event })
+    .from(schema.loggedInEvents)
+    .limit(1)
+    .all();
+
+  return (record[0]?.event as string | null | undefined) ?? null;
+}
+
+export function setActiveEvent(event: string | null | undefined): void {
+  const db = getDbOrThrow();
+  const normalizedEvent = event ?? null;
+
+  db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(schema.loggedInEvents)
+      .where(eq(schema.loggedInEvents.id, SINGLETON_ID))
+      .limit(1)
+      .all();
+
+    if (existing.length === 0) {
+      tx.insert(schema.loggedInEvents)
+        .values({ id: SINGLETON_ID, event: normalizedEvent })
+        .run();
+      return;
+    }
+
+    tx
+      .update(schema.loggedInEvents)
+      .set({ event: normalizedEvent })
+      .where(eq(schema.loggedInEvents.id, SINGLETON_ID))
+      .run();
+  });
+}
+
+export function removeActiveEvent(): void {
+  const db = getDbOrThrow();
+
+  db.transaction((tx) => {
+    tx
+      .delete(schema.loggedInEvents)
+      .where(eq(schema.loggedInEvents.id, SINGLETON_ID))
+      .run();
+  });
+}

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -65,6 +65,10 @@ function initializeExpoSqliteDb() {
       team_name TEXT NOT NULL,
       location TEXT
     );`,
+    `CREATE TABLE IF NOT EXISTS logged_in_event (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      event TEXT
+    );`,
     `CREATE TABLE IF NOT EXISTS frcevent (
       event_key TEXT PRIMARY KEY NOT NULL,
       event_name TEXT NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -10,6 +10,14 @@ export const teamRecords = sqliteTable('teamrecord', {
 export type TeamRecord = InferSelectModel<typeof teamRecords>;
 export type NewTeamRecord = InferInsertModel<typeof teamRecords>;
 
+export const loggedInEvents = sqliteTable('logged_in_event', {
+  id: integer('id').primaryKey(),
+  event: text('event'),
+});
+
+export type LoggedInEvent = InferSelectModel<typeof loggedInEvents>;
+export type NewLoggedInEvent = InferInsertModel<typeof loggedInEvents>;
+
 export const frcEvents = sqliteTable('frcevent', {
   eventKey: text('event_key').primaryKey(),
   eventName: text('event_name').notNull(),


### PR DESCRIPTION
## Summary
- add a new `logged_in_event` table to the drizzle schema and expo SQLite bootstrap
- provide helpers to set, remove, and read the active event stored in the singleton row

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eeabf72cec8326bb5ee372d5e4a847