### PR TITLE
Highlight logged-in event in event browser

### DIFF
--- a/app/screens/Settings/EventBrowserScreen.tsx
+++ b/app/screens/Settings/EventBrowserScreen.tsx
@@ -1,5 +1,12 @@
-import { useCallback, useState } from 'react';
-import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, View } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItem,
+  RefreshControl,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { Stack, useFocusEffect } from 'expo-router';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
@@ -7,12 +14,14 @@ import { ThemedText } from '@/components/themed-text';
 import { getDbOrThrow, schema } from '@/db';
 import type { FRCEvent } from '@/db/schema';
 import { useThemeColor } from '@/hooks/use-theme-color';
+import { getActiveEvent } from '../../services/logged-in-event';
 
 export function EventBrowserScreen() {
   const [events, setEvents] = useState<FRCEvent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [activeEventKey, setActiveEventKey] = useState<string | null>(null);
 
   const cardBackground = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
   const cardBorder = useThemeColor({ light: 'rgba(15, 23, 42, 0.08)', dark: 'rgba(148, 163, 184, 0.25)' }, 'text');
@@ -21,7 +30,11 @@ export function EventBrowserScreen() {
   const fetchEvents = useCallback(async () => {
     const db = getDbOrThrow();
     const rows = db.select().from(schema.frcEvents).all();
-    return [...rows].sort((a, b) => a.eventName.localeCompare(b.eventName));
+    const activeEvent = getActiveEvent();
+    return {
+      events: [...rows].sort((a, b) => a.eventName.localeCompare(b.eventName)),
+      activeEventKey: activeEvent,
+    };
   }, []);
 
   useFocusEffect(
@@ -32,11 +45,12 @@ export function EventBrowserScreen() {
       setErrorMessage(null);
 
       fetchEvents()
-        .then((data) => {
+        .then(({ events: data, activeEventKey: activeEvent }) => {
           if (!isActive) {
             return;
           }
           setEvents(data);
+          setActiveEventKey(activeEvent);
         })
         .catch((error) => {
           if (!isActive) {
@@ -64,8 +78,9 @@ export function EventBrowserScreen() {
     setIsRefreshing(true);
 
     fetchEvents()
-      .then((data) => {
+      .then(({ events: data, activeEventKey: activeEvent }) => {
         setEvents(data);
+        setActiveEventKey(activeEvent);
         setErrorMessage(null);
       })
       .catch((error) => {
@@ -78,17 +93,48 @@ export function EventBrowserScreen() {
       });
   }, [fetchEvents]);
 
-  const renderEvent = useCallback(
-    ({ item }: { item: FRCEvent }) => (
-      <View style={[styles.card, { backgroundColor: cardBackground, borderColor: cardBorder }]}>
-        <ThemedText type="defaultSemiBold" style={styles.eventName}>
-          {item.eventName}
-        </ThemedText>
-        <ThemedText style={[styles.eventMeta, { color: mutedText }]}>{item.shortName ?? item.eventKey}</ThemedText>
-        <ThemedText style={[styles.eventMeta, { color: mutedText }]}>Season {item.year} • Week {item.week}</ThemedText>
-      </View>
-    ),
-    [cardBackground, cardBorder, mutedText]
+  const activeEvent = useMemo(
+    () => events.find((event) => event.eventKey === activeEventKey) ?? null,
+    [events, activeEventKey]
+  );
+
+  const displayedEvents = useMemo(() => {
+    if (!activeEvent) {
+      return events;
+    }
+
+    const otherEvents = events.filter((event) => event.eventKey !== activeEvent.eventKey);
+    return [activeEvent, ...otherEvents];
+  }, [activeEvent, events]);
+
+  const renderEvent = useCallback<ListRenderItem<FRCEvent>>(
+    ({ item }) => {
+      const isActiveEvent = item.eventKey === activeEventKey;
+
+      return (
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: cardBackground, borderColor: cardBorder },
+            isActiveEvent ? styles.activeCard : null,
+          ]}
+        >
+          <View style={styles.cardHeader}>
+            <ThemedText type="defaultSemiBold" style={styles.eventName}>
+              {item.eventName}
+            </ThemedText>
+            {isActiveEvent ? (
+              <View style={styles.activeBadge}>
+                <ThemedText style={styles.activeBadgeText}>Logged-in event</ThemedText>
+              </View>
+            ) : null}
+          </View>
+          <ThemedText style={[styles.eventMeta, { color: mutedText }]}>{item.shortName ?? item.eventKey}</ThemedText>
+          <ThemedText style={[styles.eventMeta, { color: mutedText }]}>Season {item.year} • Week {item.week}</ThemedText>
+        </View>
+      );
+    },
+    [activeEventKey, cardBackground, cardBorder, mutedText]
   );
 
   return (
@@ -105,21 +151,42 @@ export function EventBrowserScreen() {
           <ThemedText style={styles.loadingText}>Loading events…</ThemedText>
         </View>
       ) : (
-        <FlatList
-          data={events}
-          keyExtractor={(item) => item.eventKey}
-          renderItem={renderEvent}
-          contentContainerStyle={events.length === 0 ? styles.emptyListContent : styles.listContent}
-          refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-          ListEmptyComponent={
-            <View style={styles.emptyState}>
-              <ThemedText type="defaultSemiBold">No events available</ThemedText>
-              <ThemedText style={styles.emptyStateHint}>
-                Sync general data from the App Settings screen to download the latest events.
+        <>
+          {activeEventKey && !activeEvent ? (
+            <View
+              style={[
+                styles.card,
+                styles.activeEventFallback,
+                { backgroundColor: cardBackground, borderColor: cardBorder },
+              ]}
+            >
+              <ThemedText type="defaultSemiBold" style={styles.eventName}>
+                Logged-in event
+              </ThemedText>
+              <ThemedText style={[styles.eventMeta, { color: mutedText }]}>{activeEventKey}</ThemedText>
+              <ThemedText style={[styles.activeFallbackHint, { color: mutedText }]}>
+                Sync general data from the App Settings screen to download full details for this event.
               </ThemedText>
             </View>
-          }
-        />
+          ) : null}
+          <FlatList
+            data={displayedEvents}
+            keyExtractor={(item) => item.eventKey}
+            renderItem={renderEvent}
+            contentContainerStyle={
+              displayedEvents.length === 0 ? styles.emptyListContent : styles.listContent
+            }
+            refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
+            ListEmptyComponent={
+              <View style={styles.emptyState}>
+                <ThemedText type="defaultSemiBold">No events available</ThemedText>
+                <ThemedText style={styles.emptyStateHint}>
+                  Sync general data from the App Settings screen to download the latest events.
+                </ThemedText>
+              </View>
+            }
+          />
+        </>
       )}
     </ScreenContainer>
   );
@@ -141,11 +208,38 @@ const styles = StyleSheet.create({
     padding: 16,
     gap: 8,
   },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
   eventName: {
     fontSize: 18,
   },
   eventMeta: {
     fontSize: 14,
+  },
+  activeCard: {
+    borderColor: '#0a7ea4',
+    shadowColor: '#0a7ea4',
+    shadowOpacity: 0.25,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  activeBadge: {
+    backgroundColor: '#0a7ea4',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  activeBadgeText: {
+    color: '#ffffff',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
   },
   loadingContainer: {
     flex: 1,
@@ -173,5 +267,11 @@ const styles = StyleSheet.create({
   },
   emptyStateHint: {
     textAlign: 'center',
+  },
+  activeEventFallback: {
+    marginBottom: 12,
+  },
+  activeFallbackHint: {
+    fontSize: 12,
   },
 });


### PR DESCRIPTION
## Summary
- retrieve the logged-in event when loading the event browser data
- reorder and style the event list so the active event is highlighted at the top
- display a fallback card when the logged-in event has not been synced yet

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eeb282e0088326b82616f0fe3cf648