### PR TITLE
Add organizations tables

### DIFF
--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -107,6 +107,17 @@ function initializeExpoSqliteDb() {
       FOREIGN KEY (event_key) REFERENCES frcevent(event_key),
       FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
     );`,
+    `CREATE TABLE IF NOT EXISTS organization (
+      id INTEGER PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      team_number INTEGER NOT NULL
+    );`,
+    `CREATE TABLE IF NOT EXISTS userorganization (
+      id INTEGER PRIMARY KEY NOT NULL,
+      organization_id INTEGER NOT NULL,
+      team_number INTEGER NOT NULL,
+      FOREIGN KEY (organization_id) REFERENCES organization(id)
+    );`,
   ];
 
   for (const statement of createStatements) {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -117,3 +117,31 @@ export const teamEvents = sqliteTable(
 
 export type TeamEvent = InferSelectModel<typeof teamEvents>;
 export type NewTeamEvent = InferInsertModel<typeof teamEvents>;
+
+export const organizations = sqliteTable('organization', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  teamNumber: integer('team_number').notNull(),
+});
+
+export type Organization = InferSelectModel<typeof organizations>;
+export type NewOrganization = InferInsertModel<typeof organizations>;
+
+export const userOrganizations = sqliteTable(
+  'userorganization',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    organizationId: integer('organization_id').notNull(),
+    teamNumber: integer('team_number').notNull(),
+  },
+  (table) => ({
+    organizationRef: foreignKey({
+      columns: [table.organizationId],
+      foreignColumns: [organizations.id],
+      name: 'userorganization_organization_fk',
+    }),
+  }),
+);
+
+export type UserOrganization = InferSelectModel<typeof userOrganizations>;
+export type NewUserOrganization = InferInsertModel<typeof userOrganizations>;


### PR DESCRIPTION
## Summary
- add Organizations and UserOrganizations tables to the Drizzle schema with proper typing
- create SQLite table definitions for the new entities during Expo initialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eeb478b3a88326a544fb218c1e68c4