### PR TITLE
Load organizations from database for selection

### DIFF
--- a/app/providers/OrganizationProvider.tsx
+++ b/app/providers/OrganizationProvider.tsx
@@ -1,8 +1,10 @@
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 
+import type { Organization } from '@/db/schema';
+
 interface OrganizationContextValue {
-  selectedOrganization: string | null;
-  setSelectedOrganization: (organization: string | null) => void;
+  selectedOrganization: Organization | null;
+  setSelectedOrganization: (organization: Organization | null) => void;
 }
 
 const OrganizationContext = createContext<OrganizationContextValue | undefined>(undefined);
@@ -12,7 +14,7 @@ interface OrganizationProviderProps {
 }
 
 export function OrganizationProvider({ children }: OrganizationProviderProps) {
-  const [selectedOrganization, setSelectedOrganization] = useState<string | null>(null);
+  const [selectedOrganization, setSelectedOrganization] = useState<Organization | null>(null);
 
   const value = useMemo(
     () => ({

--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -1,34 +1,148 @@
-import { useMemo } from 'react';
-import { FlatList, Pressable, StyleSheet } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { useFocusEffect } from 'expo-router';
+import { eq } from 'drizzle-orm';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
 import { useOrganization } from '@/hooks/use-organization';
+import { getDbOrThrow, schema } from '@/db';
+import type { Organization } from '@/db/schema';
 
-const ORGANIZATIONS = ['Team 2471', 'Team 971', 'Team 1678'];
+interface UserOrganizationListItem {
+  id: number;
+  organization: Organization;
+}
 
 export function OrganizationSelectScreen() {
   const { selectedOrganization, setSelectedOrganization } = useOrganization();
-  const data = useMemo(() => ORGANIZATIONS.map((name) => ({ key: name })), []);
+  const [userOrganizations, setUserOrganizations] = useState<UserOrganizationListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchUserOrganizations = useCallback(async () => {
+    const db = getDbOrThrow();
+    const rows = db
+      .select({
+        id: schema.userOrganizations.id,
+        organizationId: schema.organizations.id,
+        name: schema.organizations.name,
+        teamNumber: schema.organizations.teamNumber,
+      })
+      .from(schema.userOrganizations)
+      .innerJoin(
+        schema.organizations,
+        eq(schema.userOrganizations.organizationId, schema.organizations.id)
+      )
+      .all();
+
+    return rows
+      .map((row) => ({
+        id: row.id,
+        organization: {
+          id: row.organizationId,
+          name: row.name,
+          teamNumber: row.teamNumber,
+        },
+      }))
+      .sort((a, b) => a.organization.teamNumber - b.organization.teamNumber);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true;
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      fetchUserOrganizations()
+        .then((items) => {
+          if (!isActive) {
+            return;
+          }
+          setUserOrganizations(items);
+        })
+        .catch((error) => {
+          if (!isActive) {
+            return;
+          }
+          console.error('Failed to load user organizations', error);
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'An unexpected error occurred while loading organizations.';
+          setErrorMessage(message);
+          setUserOrganizations([]);
+        })
+        .finally(() => {
+          if (!isActive) {
+            return;
+          }
+          setIsLoading(false);
+        });
+
+      return () => {
+        isActive = false;
+      };
+    }, [fetchUserOrganizations])
+  );
+
+  useEffect(() => {
+    if (!selectedOrganization) {
+      return;
+    }
+
+    const exists = userOrganizations.some(
+      (item) => item.organization.id === selectedOrganization.id
+    );
+
+    if (!exists) {
+      setSelectedOrganization(null);
+    }
+  }, [userOrganizations, selectedOrganization, setSelectedOrganization]);
 
   return (
     <ScreenContainer>
       <ThemedText type="title">Organization</ThemedText>
       <ThemedText>Select which team or organization you are scouting for.</ThemedText>
-      <FlatList
-        data={data}
-        renderItem={({ item }) => {
-          const isActive = item.key === selectedOrganization;
-          return (
-            <Pressable
-              style={[styles.option, isActive ? styles.optionActive : undefined]}
-              onPress={() => setSelectedOrganization(item.key)}
-            >
-              <ThemedText type={isActive ? 'defaultSemiBold' : 'default'}>{item.key}</ThemedText>
-            </Pressable>
-          );
-        }}
-      />
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator accessibilityLabel="Loading organizations" color="#0a7ea4" />
+          <ThemedText style={styles.loadingText}>Loading organizations…</ThemedText>
+        </View>
+      ) : errorMessage ? (
+        <View style={styles.errorContainer}>
+          <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+        </View>
+      ) : (
+        <FlatList
+          data={userOrganizations}
+          keyExtractor={(item) => `${item.id}`}
+          renderItem={({ item }) => {
+            const isActive = item.organization.id === selectedOrganization?.id;
+
+            return (
+              <Pressable
+                style={[styles.option, isActive ? styles.optionActive : undefined]}
+                onPress={() => setSelectedOrganization(item.organization)}
+              >
+                <ThemedText type="defaultSemiBold">
+                  Team {item.organization.teamNumber}
+                </ThemedText>
+                <ThemedText style={styles.optionSubtitle}>{item.organization.name}</ThemedText>
+              </Pressable>
+            );
+          }}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <ThemedText type="defaultSemiBold">No organizations available</ThemedText>
+              <ThemedText style={styles.emptyStateHint}>
+                Sync general data from the App Settings screen to download your organizations.
+              </ThemedText>
+            </View>
+          }
+        />
+      )}
     </ScreenContainer>
   );
 }
@@ -44,5 +158,35 @@ const styles = StyleSheet.create({
   optionActive: {
     borderColor: '#0a7ea4',
     backgroundColor: '#e6f6fb',
+  },
+  optionSubtitle: {
+    marginTop: 4,
+    color: '#475569',
+  },
+  loadingContainer: {
+    marginTop: 24,
+    alignItems: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    color: '#475569',
+  },
+  errorContainer: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: '#fee2e2',
+    borderWidth: 1,
+    borderColor: '#fca5a5',
+  },
+  errorText: {
+    color: '#b91c1c',
+  },
+  emptyState: {
+    marginTop: 24,
+    gap: 8,
+  },
+  emptyStateHint: {
+    color: '#475569',
   },
 });

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -9,6 +9,7 @@ import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useAuth } from '@/hooks/use-authentication';
 import { useOrganization } from '@/hooks/use-organization';
+import type { Organization } from '@/db/schema';
 
 export type DrawerContentProps = {
   state: {
@@ -20,6 +21,10 @@ export type DrawerContentProps = {
     closeDrawer: () => void;
   };
 };
+
+function formatOrganizationLabel(organization: Organization) {
+  return `Team ${organization.teamNumber} – ${organization.name}`;
+}
 
 export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
   const { isAuthenticated, logout, displayName } = useAuth();
@@ -44,7 +49,9 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
 
   const browsingLabel = `Browsing as ${displayName ?? 'guest'}`;
   const subtitle = isAuthenticated
-    ? selectedOrganization ?? browsingLabel
+    ? selectedOrganization
+      ? formatOrganizationLabel(selectedOrganization)
+      : browsingLabel
     : browsingLabel;
 
   return (


### PR DESCRIPTION
## Summary
- load user organizations by joining the local userOrganizations and organizations tables for the selection screen
- persist the full organization model in context and surface formatted labels in the app drawer
- add loading, error, and empty states when displaying available organizations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eebe83c6948326baac1c107779c63f