### PR TITLE
Add dev logging for API authorization header

### DIFF
--- a/app/services/api/client.ts
+++ b/app/services/api/client.ts
@@ -67,6 +67,21 @@ export async function apiRequest<TResponse>(path: string, options: ApiRequestOpt
     initHeaders.set('Authorization', `Bearer ${authorizationToken}`);
   }
 
+  if (__DEV__) {
+    const method = (rest.method ?? 'GET').toUpperCase();
+    const authHeader = initHeaders.get('Authorization');
+
+    if (authHeader) {
+      const [, token] = authHeader.split(' ');
+      const preview = token ? `${token.slice(0, 8)}…` : 'missing-token';
+      // eslint-disable-next-line no-console
+      console.debug(`[apiRequest] ${method} ${url} → using bearer ${preview}`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(`[apiRequest] ${method} ${url} → no Authorization header set`);
+    }
+  }
+
   const response = await fetch(url, {
     body,
     headers: initHeaders,


### PR DESCRIPTION
## Summary
- log the HTTP method and whether an Authorization header is present on API requests during development
- truncate the bearer token preview when logging to avoid leaking full credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eedf238c988326a66c5b2e915fdfdc