### PR TITLE
Add timeout for match scout submission

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -734,10 +734,18 @@ export default function BeginScoutingRoute() {
       };
 
       try {
-        await apiRequest('/scout/submit', {
-          method: 'POST',
-          body: JSON.stringify(row),
-        });
+        const abortController = new AbortController();
+        const timeoutId = setTimeout(() => abortController.abort(), 5000);
+
+        try {
+          await apiRequest('/scout/submit', {
+            method: 'POST',
+            body: JSON.stringify(row),
+            signal: abortController.signal,
+          });
+        } finally {
+          clearTimeout(timeoutId);
+        }
 
         try {
           await syncAlreadyScoutedEntries(selectedOrganization.id);


### PR DESCRIPTION
## Summary
- abort match scout submission request after 5 seconds to avoid hanging API calls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efdefc11448326b40f37272d6ff249