### PR TITLE
Add logged-in organization persistence

### DIFF
--- a/app/screens/Settings/AppSettingsScreen.tsx
+++ b/app/screens/Settings/AppSettingsScreen.tsx
@@ -48,8 +48,12 @@ export function AppSettingsScreen() {
         const teamLabel = addedTeamsCount === 1 ? 'team' : 'teams';
         const addedOrganizationsCount = result.organizations.created;
         const organizationLabel = addedOrganizationsCount === 1 ? 'organization' : 'organizations';
+        const loggedInOrganizationMessage =
+          result.loggedInOrganization.organizationId !== null
+            ? 'Updated active organization selection.'
+            : 'No active organization selected.';
         showToast(
-          `Added ${addedTeamsCount} new ${teamLabel} and ${addedOrganizationsCount} new ${organizationLabel}.`,
+          `Added ${addedTeamsCount} new ${teamLabel} and ${addedOrganizationsCount} new ${organizationLabel}. ${loggedInOrganizationMessage}`,
         );
       },
       onError: (error) => {
@@ -176,7 +180,7 @@ export function AppSettingsScreen() {
           <View style={styles.progressRow}>
             <ActivityIndicator accessibilityLabel="Updating general data" color="#0a7ea4" />
             <ThemedText style={styles.progressText}>
-              Fetching the latest teams, events, organizations, and user assignments…
+              Fetching the latest teams, events, organizations, user assignments, and logged-in organization…
             </ThemedText>
           </View>
         ) : null}
@@ -198,6 +202,8 @@ export function AppSettingsScreen() {
               {lastResult.events.created + lastResult.events.updated} events,{' '}
               {lastResult.organizations.created + lastResult.organizations.updated} organizations, and{' '}
               {lastResult.userOrganizations.created + lastResult.userOrganizations.updated} user organization links.
+              {'\n'}Logged-in organization ID:{' '}
+              {lastResult.loggedInOrganization.organizationId ?? 'None'}
             </ThemedText>
           </View>
         ) : null}

--- a/app/services/api/user.ts
+++ b/app/services/api/user.ts
@@ -10,12 +10,24 @@ export interface UserEventResponse {
   [key: string]: unknown;
 }
 
+export interface UserOrganizationSelectionResponse {
+  organizationId?: number | null;
+  organization_id?: number | null;
+  [key: string]: unknown;
+}
+
 export const getUserInfo = async () => {
   return await apiRequest<UserInfoResponse>('/user/info');
 };
 
 export const getUserEvent = async () => {
   return await apiRequest<UserEventResponse>('/user/event', {
+    method: 'GET',
+  });
+};
+
+export const getUserOrganization = async () => {
+  return await apiRequest<UserOrganizationSelectionResponse>('/user/organization', {
     method: 'GET',
   });
 };

--- a/app/services/logged-in-organization.ts
+++ b/app/services/logged-in-organization.ts
@@ -1,0 +1,146 @@
+import { getDbOrThrow, schema } from '@/db';
+import type { Organization } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+
+const SINGLETON_ID = 1;
+
+type ActiveOrganizationListener = (organizationId: number | null) => void;
+
+const listeners = new Set<ActiveOrganizationListener>();
+let cachedOrganizationId: number | null | undefined = undefined;
+
+function readOrganizationIdFromDb(): number | null {
+  const db = getDbOrThrow();
+
+  const record = db
+    .select({ organizationId: schema.loggedInOrganizations.organizationId })
+    .from(schema.loggedInOrganizations)
+    .where(eq(schema.loggedInOrganizations.id, SINGLETON_ID))
+    .limit(1)
+    .all();
+
+  const organizationId = record[0]?.organizationId;
+
+  return typeof organizationId === 'number' ? organizationId : null;
+}
+
+function notifyListeners(organizationId: number | null) {
+  for (const listener of listeners) {
+    try {
+      listener(organizationId);
+    } catch (error) {
+      console.error('logged-in-organization listener error', error);
+    }
+  }
+}
+
+function findOrganizationById(organizationId: number): Organization | null {
+  const db = getDbOrThrow();
+
+  const record = db
+    .select()
+    .from(schema.organizations)
+    .where(eq(schema.organizations.id, organizationId))
+    .limit(1)
+    .all();
+
+  return (record[0] as Organization | undefined) ?? null;
+}
+
+function normalizeOrganizationId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function updateCache(organizationId: number | null) {
+  cachedOrganizationId = organizationId;
+}
+
+export function getActiveOrganizationId(): number | null {
+  if (cachedOrganizationId === undefined) {
+    updateCache(readOrganizationIdFromDb());
+  }
+
+  return cachedOrganizationId ?? null;
+}
+
+export function getActiveOrganization(): Organization | null {
+  const organizationId = getActiveOrganizationId();
+
+  if (organizationId === null) {
+    return null;
+  }
+
+  return findOrganizationById(organizationId);
+}
+
+export function getOrganizationById(organizationId: number | null | undefined): Organization | null {
+  if (typeof organizationId !== 'number' || !Number.isFinite(organizationId)) {
+    return null;
+  }
+
+  return findOrganizationById(organizationId);
+}
+
+export function subscribeToActiveOrganization(
+  listener: ActiveOrganizationListener,
+): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function setActiveOrganization(organizationId: number | null | undefined): void {
+  const normalizedOrganizationId = normalizeOrganizationId(organizationId);
+  const db = getDbOrThrow();
+
+  db.transaction((tx) => {
+    const existing = tx
+      .select()
+      .from(schema.loggedInOrganizations)
+      .where(eq(schema.loggedInOrganizations.id, SINGLETON_ID))
+      .limit(1)
+      .all();
+
+    if (existing.length === 0) {
+      tx
+        .insert(schema.loggedInOrganizations)
+        .values({ id: SINGLETON_ID, organizationId: normalizedOrganizationId })
+        .run();
+      return;
+    }
+
+    tx
+      .update(schema.loggedInOrganizations)
+      .set({ organizationId: normalizedOrganizationId })
+      .where(eq(schema.loggedInOrganizations.id, SINGLETON_ID))
+      .run();
+  });
+
+  updateCache(normalizedOrganizationId);
+  notifyListeners(normalizedOrganizationId);
+}
+
+export function removeActiveOrganization(): void {
+  const db = getDbOrThrow();
+
+  db.transaction((tx) => {
+    tx
+      .delete(schema.loggedInOrganizations)
+      .where(eq(schema.loggedInOrganizations.id, SINGLETON_ID))
+      .run();
+  });
+
+  updateCache(null);
+  notifyListeners(null);
+}

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -112,6 +112,11 @@ function initializeExpoSqliteDb() {
       name TEXT NOT NULL,
       team_number INTEGER NOT NULL
     );`,
+    `CREATE TABLE IF NOT EXISTS logged_in_organization (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      organization_id INTEGER,
+      FOREIGN KEY (organization_id) REFERENCES organization(id)
+    );`,
     `CREATE TABLE IF NOT EXISTS userorganization (
       id INTEGER PRIMARY KEY NOT NULL,
       organization_id INTEGER NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -18,6 +18,7 @@ export const loggedInEvents = sqliteTable('logged_in_event', {
 export type LoggedInEvent = InferSelectModel<typeof loggedInEvents>;
 export type NewLoggedInEvent = InferInsertModel<typeof loggedInEvents>;
 
+
 export const frcEvents = sqliteTable('frcevent', {
   eventKey: text('event_key').primaryKey(),
   eventName: text('event_name').notNull(),
@@ -126,6 +127,24 @@ export const organizations = sqliteTable('organization', {
 
 export type Organization = InferSelectModel<typeof organizations>;
 export type NewOrganization = InferInsertModel<typeof organizations>;
+
+export const loggedInOrganizations = sqliteTable(
+  'logged_in_organization',
+  {
+    id: integer('id').primaryKey(),
+    organizationId: integer('organization_id'),
+  },
+  (table) => ({
+    organizationRef: foreignKey({
+      columns: [table.organizationId],
+      foreignColumns: [organizations.id],
+      name: 'logged_in_organization_organization_fk',
+    }),
+  }),
+);
+
+export type LoggedInOrganization = InferSelectModel<typeof loggedInOrganizations>;
+export type NewLoggedInOrganization = InferInsertModel<typeof loggedInOrganizations>;
 
 export const userOrganizations = sqliteTable(
   'userorganization',


### PR DESCRIPTION
## Summary
- add a logged_in_organization table and local helpers to persist the active organization
- sync the logged-in organization from the /user/organization endpoint alongside general data
- hydrate the organization context and settings UI from the stored organization selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efebbe3f58832696e3fde3d13480d3