### PR TITLE
Ensure pit scout submission uses zero and empty defaults

### DIFF
--- a/app/(drawer)/pit-scout/team-details.tsx
+++ b/app/(drawer)/pit-scout/team-details.tsx
@@ -91,12 +91,12 @@ const parseOptionalInteger = (value: string) => {
   const trimmed = value.trim();
 
   if (!trimmed) {
-    return null;
+    return 0;
   }
 
   const parsed = Number.parseInt(trimmed, 10);
 
-  return Number.isNaN(parsed) ? null : parsed;
+  return Number.isNaN(parsed) ? 0 : parsed;
 };
 
 const parseCountValue = (value: string) => {
@@ -222,7 +222,7 @@ export default function PitScoutTeamDetailsScreen() {
         teamNumber: parsedTeamNumber,
         notes: '',
         drivetrain,
-        driveteam: driveTeam.trim() ? driveTeam.trim() : null,
+        driveteam: driveTeam.trim() ? driveTeam.trim() : '',
         robotWeight: parseOptionalInteger(robotWeight),
         autoNotes: normalizeNoteField(autoNotes),
         teleNotes: normalizeNoteField(teleNotes),


### PR DESCRIPTION
## Summary
- update pit scouting submission to send 0 instead of null for numeric fields
- ensure optional string fields default to empty strings when not provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eff08ba5908326a14e22dccb239a5e