### PR TITLE
Fix organization select highlight for logged-in organization

### DIFF
--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -130,6 +130,7 @@ export function OrganizationSelectScreen() {
       ) : (
         <FlatList
           data={userOrganizations}
+          extraData={selectedOrganization?.id}
           keyExtractor={(item) => `${item.id}`}
           renderItem={({ item }) => {
             const isActive = item.organization.id === selectedOrganization?.id;


### PR DESCRIPTION
## Summary
- ensure the organization selection list re-renders when the active organization changes so the logged-in org is highlighted by default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efefd1109883269f70459dc82d0fe6