### PR TITLE
Add drawer sync button to synchronize event data

### DIFF
--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -1,0 +1,83 @@
+import { getUserEvent } from './api/user';
+import { apiRequest } from './api/client';
+import { retrieveEventInfo, type RetrieveEventInfoResult } from './event-info';
+import { getActiveEvent, setActiveEvent } from './logged-in-event';
+import { syncAlreadyScoutedEntries } from './already-scouted';
+import { syncAlreadyPitScoutedEntries } from './pit-scouting';
+import { getDbOrThrow, schema } from '@/db';
+import { eq } from 'drizzle-orm';
+
+export type SyncDataWithServerResult = {
+  eventCode: string;
+  eventChanged: boolean;
+  eventInfo: RetrieveEventInfoResult;
+  matchDataSent: number;
+  pitDataSent: number;
+  alreadyScoutedUpdated: number;
+  alreadyPitScoutedUpdated: number;
+};
+
+const normalizeEventCode = (rawEventCode: unknown): string | null => {
+  if (typeof rawEventCode !== 'string') {
+    return null;
+  }
+
+  const trimmed = rawEventCode.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export async function syncDataWithServer(organizationId: number): Promise<SyncDataWithServerResult> {
+  const userEventResponse = await getUserEvent();
+  const remoteEventCode = normalizeEventCode(userEventResponse?.eventCode);
+  const currentEventCode = getActiveEvent();
+
+  if (remoteEventCode !== currentEventCode) {
+    setActiveEvent(remoteEventCode);
+  }
+
+  if (!remoteEventCode) {
+    throw new Error('No event is currently assigned to your account.');
+  }
+
+  const eventInfo = await retrieveEventInfo();
+  const db = getDbOrThrow();
+
+  const matchRows = db
+    .select()
+    .from(schema.matchData2025)
+    .where(eq(schema.matchData2025.eventKey, remoteEventCode))
+    .all();
+
+  if (matchRows.length > 0) {
+    await apiRequest('/scout/submit/batch', {
+      method: 'POST',
+      body: JSON.stringify(matchRows),
+    });
+  }
+
+  const pitRows = db
+    .select()
+    .from(schema.pitData2025)
+    .where(eq(schema.pitData2025.eventKey, remoteEventCode))
+    .all();
+
+  if (pitRows.length > 0) {
+    await apiRequest('/scout/pit/batch', {
+      method: 'POST',
+      body: JSON.stringify(pitRows),
+    });
+  }
+
+  const alreadyScoutedUpdated = await syncAlreadyScoutedEntries(organizationId);
+  const alreadyPitScoutedUpdated = await syncAlreadyPitScoutedEntries(organizationId);
+
+  return {
+    eventCode: remoteEventCode,
+    eventChanged: remoteEventCode !== currentEventCode,
+    eventInfo,
+    matchDataSent: matchRows.length,
+    pitDataSent: pitRows.length,
+    alreadyScoutedUpdated,
+    alreadyPitScoutedUpdated,
+  };
+}


### PR DESCRIPTION
## Summary
- add a drawer action that syncs the current event, submissions, and already-scouted entries
- implement a shared service that performs the sync workflow across match, pit, and already-scouted data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eff6b161908326aa47c722f278a4af