### PR TITLE
Handle remote organization switching and trigger sync

### DIFF
--- a/app/services/api/user.ts
+++ b/app/services/api/user.ts
@@ -31,3 +31,29 @@ export const getUserOrganization = async () => {
     method: 'GET',
   });
 };
+
+export const updateUserOrganizationSelection = async (userOrganizationId: number) => {
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => {
+    abortController.abort();
+  }, 5_000);
+
+  try {
+    return await apiRequest<UserOrganizationSelectionResponse>('/user/organization', {
+      method: 'PATCH',
+      body: JSON.stringify({ user_organization_id: userOrganizationId }),
+      signal: abortController.signal,
+    });
+  } catch (error) {
+    if (
+      (error instanceof DOMException && error.name === 'AbortError') ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      throw new Error('Request timed out after 5 seconds');
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};


### PR DESCRIPTION
## Summary
- add an API helper to PATCH `/user/organization` with a 5s timeout for switching assignments
- update the organization selection screen to call the server before changing state, persist the returned org id, and show sync feedback
- trigger the same sync flow used in the drawer after a successful switch and surface errors to the user

## Testing
- npm run lint
- npx tsc --noEmit *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68effa658c2c832697c956624388575f