### PR TITLE
Ensure organization switch refreshes selection

### DIFF
--- a/app/services/api/user.ts
+++ b/app/services/api/user.ts
@@ -39,11 +39,13 @@ export const updateUserOrganizationSelection = async (userOrganizationId: number
   }, 5_000);
 
   try {
-    return await apiRequest<UserOrganizationSelectionResponse>('/user/organization', {
+    await apiRequest<UserOrganizationSelectionResponse>('/user/organization', {
       method: 'PATCH',
       body: JSON.stringify({ user_organization_id: userOrganizationId }),
       signal: abortController.signal,
     });
+
+    return await getUserOrganization();
   } catch (error) {
     if (
       (error instanceof DOMException && error.name === 'AbortError') ||


### PR DESCRIPTION
## Summary
- update the organization selection API helper to fetch the latest selection after patching
- ensure the organization picker receives a response that includes the new organization id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f00047f3f08326b2b876d969ed4176