### PR TITLE
Add organization application workflow

### DIFF
--- a/app/(drawer)/organization-select/apply.tsx
+++ b/app/(drawer)/organization-select/apply.tsx
@@ -1,0 +1,5 @@
+import { OrganizationApplyScreen } from '@/app/screens';
+
+export default function OrganizationApplyRoute() {
+  return <OrganizationApplyScreen />;
+}

--- a/app/screens/Settings/OrganizationApplyScreen.tsx
+++ b/app/screens/Settings/OrganizationApplyScreen.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useState } from 'react';
+import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { getDbOrThrow, schema } from '@/db';
+import { applyToOrganization, fetchOrganizations, type OrganizationListItem } from '@/app/services/api';
+
+const useUserOrganizationIds = () => {
+  const loadOrganizationIds = useCallback(() => {
+    const db = getDbOrThrow();
+    const rows = db
+      .select({ organizationId: schema.userOrganizations.organizationId })
+      .from(schema.userOrganizations)
+      .all();
+
+    return new Set(rows.map((row) => row.organizationId));
+  }, []);
+
+  return loadOrganizationIds;
+};
+
+export function OrganizationApplyScreen() {
+  const colorScheme = useColorScheme();
+  const isDarkMode = colorScheme === 'dark';
+  const accentColor = '#0a7ea4';
+  const optionBorderColor = isDarkMode ? '#3f3f46' : '#ccc';
+  const optionBackgroundColor = isDarkMode ? 'rgba(255, 255, 255, 0.03)' : '#fff';
+  const optionActiveBackgroundColor = isDarkMode ? 'rgba(10, 126, 164, 0.2)' : '#e6f6fb';
+  const secondaryTextColor = isDarkMode ? '#94a3b8' : '#475569';
+
+  const router = useRouter();
+  const getUserOrganizationIds = useUserOrganizationIds();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [organizations, setOrganizations] = useState<OrganizationListItem[]>([]);
+  const [pendingOrganizationId, setPendingOrganizationId] = useState<number | null>(null);
+
+  const loadOrganizations = useCallback(async () => {
+    const userOrganizationIds = getUserOrganizationIds();
+    const availableOrganizations = await fetchOrganizations();
+
+    return availableOrganizations.filter((organization) => !userOrganizationIds.has(organization.id));
+  }, [getUserOrganizationIds]);
+
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true;
+
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      loadOrganizations()
+        .then((items) => {
+          if (!isActive) {
+            return;
+          }
+
+          setOrganizations(items);
+        })
+        .catch((error) => {
+          if (!isActive) {
+            return;
+          }
+
+          console.error('Failed to load organizations for application', error);
+          setOrganizations([]);
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : 'An unexpected error occurred while loading organizations.',
+          );
+        })
+        .finally(() => {
+          if (!isActive) {
+            return;
+          }
+
+          setIsLoading(false);
+        });
+
+      return () => {
+        isActive = false;
+      };
+    }, [loadOrganizations]),
+  );
+
+  const handleOrganizationApplyPress = useCallback(
+    async (organization: OrganizationListItem) => {
+      if (pendingOrganizationId !== null) {
+        return;
+      }
+
+      setPendingOrganizationId(organization.id);
+
+      try {
+        await applyToOrganization(organization.id);
+        Alert.alert(
+          'Application sent',
+          `Your request to join Team ${organization.teamNumber} has been submitted.`,
+        );
+        router.replace('/(drawer)/pit-scout');
+      } catch (error) {
+        console.error('Failed to apply to organization', error);
+        Alert.alert(
+          'Application failed',
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred while submitting your application.',
+        );
+      } finally {
+        setPendingOrganizationId(null);
+      }
+    },
+    [pendingOrganizationId, router],
+  );
+
+  return (
+    <ScreenContainer>
+      <View style={styles.header}>
+        <ThemedText type="title">Apply to an Organization</ThemedText>
+      </View>
+      <ThemedText>Choose an organization to request access to.</ThemedText>
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator accessibilityLabel="Loading organizations" color={accentColor} />
+          <ThemedText style={[styles.loadingText, { color: secondaryTextColor }]}>
+            Loading organizations…
+          </ThemedText>
+        </View>
+      ) : errorMessage ? (
+        <View style={styles.errorContainer}>
+          <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+        </View>
+      ) : (
+        <FlatList
+          data={organizations}
+          keyExtractor={(item) => `${item.id}`}
+          renderItem={({ item }) => {
+            const isPending = pendingOrganizationId === item.id;
+            const isDisabled = pendingOrganizationId !== null && !isPending;
+
+            return (
+              <Pressable
+                accessibilityState={{ busy: isPending || undefined }}
+                disabled={isDisabled}
+                onPress={() => handleOrganizationApplyPress(item)}
+                style={[
+                  styles.option,
+                  {
+                    borderColor: optionBorderColor,
+                    backgroundColor: optionBackgroundColor,
+                  },
+                  isPending && {
+                    borderColor: accentColor,
+                    backgroundColor: optionActiveBackgroundColor,
+                  },
+                  isDisabled && styles.disabledOption,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold">Team {item.teamNumber}</ThemedText>
+                <ThemedText style={[styles.optionSubtitle, { color: secondaryTextColor }]}>
+                  {item.name}
+                </ThemedText>
+                {isPending ? (
+                  <ActivityIndicator
+                    accessibilityLabel="Submitting application"
+                    color={accentColor}
+                    style={styles.optionLoadingIndicator}
+                  />
+                ) : null}
+              </Pressable>
+            );
+          }}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <ThemedText type="defaultSemiBold">No organizations available</ThemedText>
+              <ThemedText style={[styles.emptyStateHint, { color: secondaryTextColor }]}>
+                All available organizations are already linked to your account.
+              </ThemedText>
+            </View>
+          }
+        />
+      )}
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  option: {
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    marginTop: 16,
+  },
+  disabledOption: {
+    opacity: 0.6,
+  },
+  optionSubtitle: {
+    marginTop: 4,
+  },
+  optionLoadingIndicator: {
+    marginTop: 12,
+    alignSelf: 'flex-start',
+  },
+  loadingContainer: {
+    marginTop: 24,
+    alignItems: 'center',
+    gap: 12,
+  },
+  loadingText: {},
+  errorContainer: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: '#fee2e2',
+    borderWidth: 1,
+    borderColor: '#fca5a5',
+  },
+  errorText: {
+    color: '#b91c1c',
+  },
+  emptyState: {
+    marginTop: 24,
+    gap: 8,
+  },
+  emptyStateHint: {},
+});

--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, View } from 'react-native';
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import { eq } from 'drizzle-orm';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
@@ -61,6 +61,7 @@ export function OrganizationSelectScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [pendingUserOrganizationId, setPendingUserOrganizationId] = useState<number | null>(null);
+  const router = useRouter();
   const colorScheme = useColorScheme();
   const isDarkMode = colorScheme === 'dark';
   const accentColor = '#0a7ea4';
@@ -204,7 +205,18 @@ export function OrganizationSelectScreen() {
 
   return (
     <ScreenContainer>
-      <ThemedText type="title">Organization</ThemedText>
+      <View style={styles.header}>
+        <ThemedText type="title" style={styles.headerTitle}>
+          Organization
+        </ThemedText>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.push('/(drawer)/organization-select/apply')}
+          style={[styles.applyButton, { backgroundColor: accentColor }]}
+        >
+          <ThemedText style={styles.applyButtonText}>Apply to Organization</ThemedText>
+        </Pressable>
+      </View>
       <ThemedText>Select which team or organization you are scouting for.</ThemedText>
       {isLoading ? (
         <View style={styles.loadingContainer}>
@@ -279,6 +291,26 @@ export function OrganizationSelectScreen() {
 }
 
 const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    flexWrap: 'wrap',
+    marginBottom: 12,
+  },
+  headerTitle: {
+    flexShrink: 1,
+  },
+  applyButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+  },
+  applyButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
   option: {
     padding: 12,
     borderRadius: 8,

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -5,5 +5,6 @@ export { MatchScoutScreen } from './MatchScout/MatchScoutScreen';
 export { MatchTeamSelectScreen } from './MatchScout/MatchTeamSelectScreen';
 export { AppSettingsScreen } from './Settings/AppSettingsScreen';
 export { EventBrowserScreen } from './Settings/EventBrowserScreen';
+export { OrganizationApplyScreen } from './Settings/OrganizationApplyScreen';
 export { OrganizationSelectScreen } from './Settings/OrganizationSelectScreen';
 export { UserSettingsScreen } from './Settings/UserSettingsScreen';

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -1,4 +1,5 @@
 export * from './base';
 export * from './client';
 export * from './ping';
+export * from './organizations';
 export * from './user';

--- a/app/services/api/organizations.ts
+++ b/app/services/api/organizations.ts
@@ -1,0 +1,95 @@
+import { apiRequest } from './client';
+
+export interface OrganizationResponse {
+  id?: number | null;
+  name?: string | null;
+  team_number?: number | null;
+}
+
+type OrganizationsApiResponse =
+  | OrganizationResponse[]
+  | {
+      data?: OrganizationResponse[] | {
+        data?: OrganizationResponse[];
+        items?: OrganizationResponse[];
+        results?: OrganizationResponse[];
+      };
+      items?: OrganizationResponse[];
+      results?: OrganizationResponse[];
+    };
+
+export type OrganizationListItem = {
+  id: number;
+  name: string;
+  teamNumber: number;
+};
+
+const extractOrganizationItems = (
+  response: OrganizationsApiResponse,
+): OrganizationResponse[] => {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  const possibleCollections = [
+    response?.data,
+    response?.items,
+    response?.results,
+    response?.data && typeof response.data === 'object'
+      ? 'data' in response.data
+        ? (response.data as { data?: OrganizationResponse[] }).data
+        : undefined
+      : undefined,
+    response?.data && typeof response.data === 'object'
+      ? 'items' in response.data
+        ? (response.data as { items?: OrganizationResponse[] }).items
+        : undefined
+      : undefined,
+    response?.data && typeof response.data === 'object'
+      ? 'results' in response.data
+        ? (response.data as { results?: OrganizationResponse[] }).results
+        : undefined
+      : undefined,
+  ];
+
+  for (const collection of possibleCollections) {
+    if (Array.isArray(collection)) {
+      return collection;
+    }
+  }
+
+  return [];
+};
+
+export const fetchOrganizations = async (): Promise<OrganizationListItem[]> => {
+  const response = await apiRequest<OrganizationsApiResponse>('/organizations', {
+    method: 'GET',
+  });
+
+  const organizations = extractOrganizationItems(response);
+
+  return organizations
+    .filter((organization) => {
+      return (
+        typeof organization?.id === 'number' &&
+        Number.isFinite(organization.id) &&
+        typeof organization?.team_number === 'number' &&
+        Number.isFinite(organization.team_number) &&
+        typeof organization?.name === 'string' &&
+        organization.name.trim().length > 0
+      );
+    })
+    .map((organization) => ({
+      id: organization.id as number,
+      name: (organization.name ?? '').trim(),
+      teamNumber: organization.team_number as number,
+    }))
+    .sort((a, b) => a.teamNumber - b.teamNumber);
+};
+
+export const applyToOrganization = async (organizationId: number) => {
+  await apiRequest('/user/organization/apply', {
+    method: 'POST',
+    body: JSON.stringify({ organization_id: organizationId }),
+  });
+};


### PR DESCRIPTION
## Summary
- add an Apply to Organization action on the organization selection screen
- introduce a dedicated organization application screen backed by new API helpers
- register the new route so users can request access and return to pit scouting after applying

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0068e5b6c8326bb655431666d326d