### PR TITLE
Refresh organization list on select screen focus

### DIFF
--- a/app/services/general-data.ts
+++ b/app/services/general-data.ts
@@ -67,6 +67,11 @@ export type UpdateGeneralDataResult = {
   loggedInOrganization: LoggedInOrganizationSyncResult;
 };
 
+export type RefreshUserOrganizationsResult = {
+  userOrganizations: UpsertResult;
+  loggedInOrganization: LoggedInOrganizationSyncResult;
+};
+
 type LoggedInEventSyncResult = {
   eventCode: string | null;
 };
@@ -545,4 +550,11 @@ export async function updateGeneralData(): Promise<UpdateGeneralDataResult> {
   const loggedInEvent = await syncLoggedInEvent();
 
   return { teams, events, organizations, userOrganizations, loggedInOrganization, loggedInEvent };
+}
+
+export async function refreshUserOrganizations(): Promise<RefreshUserOrganizationsResult> {
+  const userOrganizations = await syncUserOrganizations();
+  const loggedInOrganization = await syncLoggedInOrganization();
+
+  return { userOrganizations, loggedInOrganization };
 }


### PR DESCRIPTION
## Summary
- add a helper to refresh user organizations from the API and update the logged-in organization cache
- trigger a refresh when the organization select screen gains focus before reading from the local database

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f00ae379c48326b62391c008be4005