### PR TITLE
Exclude pending organizations from selection screen

### DIFF
--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -17,6 +17,7 @@ import type { UserOrganizationSelectionResponse } from '@/app/services/api/user'
 
 interface UserOrganizationListItem {
   id: number;
+  role: string | null;
   organization: Organization;
 }
 
@@ -80,6 +81,7 @@ export function OrganizationSelectScreen() {
         organizationId: schema.organizations.id,
         name: schema.organizations.name,
         teamNumber: schema.organizations.teamNumber,
+        role: schema.userOrganizations.role,
       })
       .from(schema.userOrganizations)
       .innerJoin(
@@ -89,14 +91,23 @@ export function OrganizationSelectScreen() {
       .all();
 
     return rows
-      .map((row) => ({
-        id: row.id,
-        organization: {
-          id: row.organizationId,
-          name: row.name,
-          teamNumber: row.teamNumber,
-        },
-      }))
+      .map((row): UserOrganizationListItem => {
+        const role =
+          typeof row.role === 'string' && row.role.trim().length > 0
+            ? row.role.trim().toUpperCase()
+            : null;
+
+        return {
+          id: row.id,
+          role,
+          organization: {
+            id: row.organizationId,
+            name: row.name,
+            teamNumber: row.teamNumber,
+          },
+        };
+      })
+      .filter((row) => row.role !== 'PENDING')
       .sort((a, b) => a.organization.teamNumber - b.organization.teamNumber);
   }, []);
 

--- a/app/services/general-data.ts
+++ b/app/services/general-data.ts
@@ -31,6 +31,12 @@ type UserOrganizationResponse = {
   organization_id?: number;
   team_number?: number;
   user_organization_id?: number;
+  role?: string | null;
+  user_role?: string | null;
+  organization_role?: string | null;
+  status?: string | null;
+  membership_status?: string | null;
+  membershipStatus?: string | null;
 };
 
 type PaginatedResponseMeta = {
@@ -104,6 +110,7 @@ type NormalizedUserOrganization = {
   id: number;
   organizationId: number;
   teamNumber: number;
+  role: string | null;
 };
 
 const normalizeUserOrganization = (
@@ -130,11 +137,33 @@ const normalizeUserOrganization = (
       ? userOrganization.team_number
       : null;
 
+  const possibleRoles = [
+    userOrganization.role,
+    userOrganization.user_role,
+    userOrganization.organization_role,
+    userOrganization.status,
+    userOrganization.membership_status,
+    userOrganization.membershipStatus,
+  ];
+
+  let role: string | null = null;
+
+  for (const possibleRole of possibleRoles) {
+    if (typeof possibleRole === 'string') {
+      const normalizedRole = possibleRole.trim();
+
+      if (normalizedRole.length > 0) {
+        role = normalizedRole.toUpperCase();
+        break;
+      }
+    }
+  }
+
   if (id === null || organizationId === null || teamNumber === null) {
     return null;
   }
 
-  return { id, organizationId, teamNumber };
+  return { id, organizationId, teamNumber, role };
 };
 
 function extractItems<T>(response: PaginatedResponse<T>): T[] {
@@ -479,7 +508,8 @@ async function syncUserOrganizations(): Promise<UpsertResult> {
 
       if (
         existingRecord.organizationId !== normalized.organizationId ||
-        existingRecord.teamNumber !== normalized.teamNumber
+        existingRecord.teamNumber !== normalized.teamNumber ||
+        existingRecord.role !== normalized.role
       ) {
         tx
           .update(schema.userOrganizations)

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -152,6 +152,7 @@ export const userOrganizations = sqliteTable(
     id: integer('id').primaryKey({ autoIncrement: true }),
     organizationId: integer('organization_id').notNull(),
     teamNumber: integer('team_number').notNull(),
+    role: text('role'),
   },
   (table) => ({
     organizationRef: foreignKey({


### PR DESCRIPTION
## Summary
- store the membership role returned by the API when syncing user organizations
- filter out pending roles so they no longer appear in the organization selection list

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68f013421804832697d072b93a6f18d4