### PR TITLE
Ensure prescout navigation preserves selected team

### DIFF
--- a/app/screens/Prescout/PrescoutScreen.tsx
+++ b/app/screens/Prescout/PrescoutScreen.tsx
@@ -8,14 +8,22 @@ export function PrescoutScreen() {
 
   const handleTeamPress = (team: TeamListItem) => {
     const activeEventKey = getActiveEvent();
+    const teamNumberParam = String(team.number);
+
+    const params: Record<string, string> = {
+      mode: 'prescout',
+      teamNumber: teamNumberParam,
+      team_number: teamNumberParam,
+    };
+
+    if (activeEventKey) {
+      params.eventKey = activeEventKey;
+      params.event_key = activeEventKey;
+    }
 
     router.push({
       pathname: '/(drawer)/match-scout/begin-scouting',
-      params: {
-        mode: 'prescout',
-        teamNumber: String(team.number),
-        eventKey: activeEventKey ?? undefined,
-      },
+      params,
     });
   };
 


### PR DESCRIPTION
## Summary
- ensure the prescout team selection forwards both camelCase and snake_case params so the selected team is preserved when navigating to begin scouting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5af7a26dc8326927161344eb9dc41