### PR TITLE
Ensure prescout team selection updates with route params

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -481,6 +481,12 @@ export default function BeginScoutingRoute() {
     setMatchNumber(String(nextMatchNumberValue));
   };
 
+  useEffect(() => {
+    if (isPrescoutMode) {
+      setTeamNumber(initialTeamNumber);
+    }
+  }, [initialTeamNumber, isPrescoutMode]);
+
   const inputBackground = useThemeColor({ light: '#FFFFFF', dark: '#0F172A' }, 'background');
   const inputBorder = useThemeColor({ light: '#CBD5F5', dark: '#334155' }, 'background');
   const textColor = useThemeColor({}, 'text');

--- a/app/screens/Prescout/PrescoutScreen.tsx
+++ b/app/screens/Prescout/PrescoutScreen.tsx
@@ -8,14 +8,22 @@ export function PrescoutScreen() {
 
   const handleTeamPress = (team: TeamListItem) => {
     const activeEventKey = getActiveEvent();
+    const teamNumberParam = String(team.number);
+
+    const params: Record<string, string> = {
+      mode: 'prescout',
+      teamNumber: teamNumberParam,
+      team_number: teamNumberParam,
+    };
+
+    if (activeEventKey) {
+      params.eventKey = activeEventKey;
+      params.event_key = activeEventKey;
+    }
 
     router.push({
       pathname: '/(drawer)/match-scout/begin-scouting',
-      params: {
-        mode: 'prescout',
-        teamNumber: String(team.number),
-        eventKey: activeEventKey ?? undefined,
-      },
+      params,
     });
   };
 


### PR DESCRIPTION
## Summary
- sync the prescout team number field with the latest route params when navigating to begin scouting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f5af7a26dc8326927161344eb9dc41