### PR TITLE
Update Expo scheme and redirect for CodyStats

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "frcredzone",
+    "scheme": "codystats",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
@@ -26,7 +26,7 @@
       "favicon": "./assets/images/favicon.png"
     },
     "extra": {
-      "supabaseRedirect": "frcredzone://auth"
+      "supabaseRedirect": "codystats://auth"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary
- replace the Expo deep link scheme with the new codystats identifier
- update the Supabase redirect URL to use the codystats scheme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f662266eb0832681daf2d79982426f