### PR TITLE
Add Robot Photos drawer entry

### DIFF
--- a/app/(drawer)/robot-photos/index.tsx
+++ b/app/(drawer)/robot-photos/index.tsx
@@ -1,0 +1,5 @@
+import { RobotPhotosScreen } from '@/app/screens';
+
+export default function RobotPhotosRoute() {
+  return <RobotPhotosScreen />;
+}

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -16,6 +16,7 @@ export const DRAWER_ITEMS: {
   { name: 'pit-scout/index', title: 'Pit Scout', href: ROUTES.pitScout, icon: 'build-outline' },
   { name: 'match-scout/index', title: 'Match Scout', href: ROUTES.matchScout, icon: 'trophy-outline' },
   { name: 'prescout/index', title: 'Prescout', href: ROUTES['prescout'], icon: 'search-outline' },
+  { name: 'robot-photos/index', title: 'Robot Photos', href: ROUTES.robotPhotos, icon: 'camera-outline' },
   { name: 'settings/index', title: 'App Settings', href: ROUTES.appSettings, icon: 'settings-outline' },
   {
     name: 'organization-select/index',

--- a/app/screens/RobotPhotos/RobotPhotosScreen.tsx
+++ b/app/screens/RobotPhotos/RobotPhotosScreen.tsx
@@ -1,0 +1,5 @@
+import { TeamListScreen } from '@/app/screens/Shared/TeamListScreen';
+
+export function RobotPhotosScreen() {
+  return <TeamListScreen title="Robot Photos" />;
+}

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -1,6 +1,7 @@
 export { LoginScreen } from './Auth/LoginScreen';
 export { PitScoutScreen } from './PitScout/PitScoutScreen';
 export { PrescoutScreen } from './Prescout/PrescoutScreen';
+export { RobotPhotosScreen } from './RobotPhotos/RobotPhotosScreen';
 export { MatchScoutScreen } from './MatchScout/MatchScoutScreen';
 export { MatchTeamSelectScreen } from './MatchScout/MatchTeamSelectScreen';
 export { AppSettingsScreen } from './Settings/AppSettingsScreen';

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   pitScout: '/(drawer)/pit-scout' as const,
   matchScout: '/(drawer)/match-scout' as const,
   prescout: '/(drawer)/prescout' as const,
+  robotPhotos: '/(drawer)/robot-photos' as const,
   appSettings: '/(drawer)/settings' as const,
   eventsBrowser: '/(drawer)/settings/events' as const,
   organizationSelect: '/(drawer)/organization-select' as const,


### PR DESCRIPTION
## Summary
- add a Robot Photos item to the drawer navigation
- implement the Robot Photos screen to reuse the shared team list view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd1a6ff3288326933782dc950caa7b