### PR TITLE
Add robot photo metadata table

### DIFF
--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -126,12 +126,14 @@ function initializeExpoSqliteDb() {
     );`,
     `CREATE TABLE IF NOT EXISTS robot_photos (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_key TEXT NOT NULL,
       team_number INTEGER NOT NULL,
       local_uri TEXT NOT NULL,
       remote_url TEXT,
       upload_pending INTEGER NOT NULL DEFAULT 1,
       created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
-      FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
+      FOREIGN KEY (team_number) REFERENCES teamrecord(team_number),
+      FOREIGN KEY (event_key) REFERENCES frcevent(event_key)
     );`,
     `CREATE TABLE IF NOT EXISTS pitdata2025 (
       event_key TEXT NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -170,6 +170,7 @@ export const robotPhotos = sqliteTable(
   'robot_photos',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
+    eventKey: text('event_key').notNull(),
     teamNumber: integer('team_number')
       .notNull(),
     localUri: text('local_uri').notNull(),
@@ -182,6 +183,11 @@ export const robotPhotos = sqliteTable(
       columns: [table.teamNumber],
       foreignColumns: [teamRecords.teamNumber],
       name: 'robot_photos_team_fk',
+    }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'robot_photos_event_fk',
     }),
   }),
 );


### PR DESCRIPTION
## Summary
- define a new `robot_photos` table and TypeScript types for robot photo metadata
- ensure the SQLite initialization path creates the table with defaults and foreign key constraint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd1edf6cb483268222cb40c96dddc9