### PR TITLE
Add robot photo capture utility

### DIFF
--- a/src/services/robotPhotos.ts
+++ b/src/services/robotPhotos.ts
@@ -1,0 +1,48 @@
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+
+import { getDbOrThrow, schema } from '@/db';
+import { getActiveEvent } from '@/app/services/logged-in-event';
+
+export async function takeRobotPhoto(teamNumber: number): Promise<string | null> {
+  const result = await ImagePicker.launchCameraAsync({
+    quality: 0.8,
+    base64: false,
+  });
+
+  if (result.canceled || !result.assets?.[0]?.uri) {
+    return null;
+  }
+
+  const eventKey = getActiveEvent();
+
+  if (!eventKey) {
+    throw new Error('Cannot capture robot photo without an active event.');
+  }
+
+  const sourceUri = result.assets[0].uri;
+  const directory = `${FileSystem.documentDirectory}robotPhotos`;
+
+  await FileSystem.makeDirectoryAsync(directory, { intermediates: true });
+
+  const destinationUri = `${directory}/${teamNumber}_${Date.now()}.jpg`;
+
+  await FileSystem.copyAsync({
+    from: sourceUri,
+    to: destinationUri,
+  });
+
+  const db = getDbOrThrow();
+
+  await db
+    .insert(schema.robotPhotos)
+    .values({
+      eventKey,
+      teamNumber,
+      localUri: destinationUri,
+      uploadPending: 1,
+    })
+    .run();
+
+  return destinationUri;
+}


### PR DESCRIPTION
## Summary
- add a robot photo capture helper that uses Expo ImagePicker and FileSystem
- store the captured photo metadata in the local database with the active event and mark it for upload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd218f2ea08326add5707da561d26d