### PR TITLE
Request camera permission before taking robot photos

### DIFF
--- a/app/screens/RobotPhotos/TeamRobotPhotosScreen.tsx
+++ b/app/screens/RobotPhotos/TeamRobotPhotosScreen.tsx
@@ -18,7 +18,7 @@ import { ThemedText } from '@/components/themed-text';
 import { useThemeColor } from '@/hooks/use-theme-color';
 import { getDbOrThrow, schema } from '@/db';
 import { getActiveEvent } from '@/app/services/logged-in-event';
-import { takeRobotPhoto } from '@/src/services/robotPhotos';
+import { ensureCameraPermission, takeRobotPhoto } from '@/src/services/robotPhotos';
 
 interface PhotoItem {
   id: number;
@@ -129,6 +129,16 @@ export function TeamRobotPhotosScreen() {
 
     try {
       setIsTakingPhoto(true);
+      const hasPermission = await ensureCameraPermission();
+
+      if (!hasPermission) {
+        Alert.alert(
+          'Camera permission required',
+          'Please enable camera access in your device settings to take robot photos.'
+        );
+        return;
+      }
+
       const uri = await takeRobotPhoto(teamNumber);
 
       if (!uri) {

--- a/src/services/robotPhotos.ts
+++ b/src/services/robotPhotos.ts
@@ -4,6 +4,18 @@ import * as FileSystem from 'expo-file-system';
 import { getDbOrThrow, schema } from '@/db';
 import { getActiveEvent } from '@/app/services/logged-in-event';
 
+export async function ensureCameraPermission(): Promise<boolean> {
+  const existingPermission = await ImagePicker.getCameraPermissionsAsync();
+
+  if (existingPermission.granted) {
+    return true;
+  }
+
+  const requestedPermission = await ImagePicker.requestCameraPermissionsAsync();
+
+  return requestedPermission.granted;
+}
+
 export async function takeRobotPhoto(teamNumber: number): Promise<string | null> {
   const result = await ImagePicker.launchCameraAsync({
     quality: 0.8,


### PR DESCRIPTION
## Summary
- add a helper to request camera access before opening the camera
- prompt the user to enable camera permissions when taking robot photos without access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd252a35bc83269663e9fbf6c77183