### PR TITLE
Avoid deleting organizations during user organization refresh

### DIFF
--- a/app/services/general-data.ts
+++ b/app/services/general-data.ts
@@ -449,10 +449,11 @@ async function syncOrganizations(): Promise<UpsertResult> {
           .delete(schema.userOrganizations)
           .where(eq(schema.userOrganizations.organizationId, existingOrganization.id))
           .run();
-        tx
-          .delete(schema.organizations)
-          .where(eq(schema.organizations.id, existingOrganization.id))
-          .run();
+
+        // Avoid deleting the organization record itself so that any tables with
+        // foreign keys (for example, already scouted data) continue to reference
+        // a valid organization. This prevents refreshes from failing when the
+        // API omits an organization that still has related local data.
       }
     }
   });


### PR DESCRIPTION
## Summary
- keep organization records when refreshing user organizations to prevent foreign-key violations when related local data exists
- document the intent so future cleanup avoids breaking already-scouted tables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe870546ac8326aceaf88fda3b3a76