### PR TITLE
Sync user assignments on session changes

### DIFF
--- a/app/services/full-sync.ts
+++ b/app/services/full-sync.ts
@@ -1,0 +1,30 @@
+import { retrieveEventInfo, type RetrieveEventInfoResult } from './event-info';
+import { updateGeneralData, type UpdateGeneralDataResult } from './general-data';
+import { getActiveEvent } from './logged-in-event';
+import { getActiveOrganizationId } from './logged-in-organization';
+import { syncDataWithServer, type SyncDataWithServerResult } from './sync-data';
+
+export type FullSyncResult = {
+  generalData: UpdateGeneralDataResult;
+  eventInfo: RetrieveEventInfoResult | null;
+  dataSync: SyncDataWithServerResult | null;
+};
+
+export async function runFullSync(): Promise<FullSyncResult> {
+  const generalData = await updateGeneralData();
+
+  const organizationId = getActiveOrganizationId();
+  const activeEvent = getActiveEvent();
+
+  let dataSync: SyncDataWithServerResult | null = null;
+  let eventInfo: RetrieveEventInfoResult | null = null;
+
+  if (organizationId !== null) {
+    dataSync = await syncDataWithServer(organizationId);
+    eventInfo = dataSync.eventInfo;
+  } else if (activeEvent) {
+    eventInfo = await retrieveEventInfo();
+  }
+
+  return { generalData, eventInfo, dataSync };
+}

--- a/app/services/user-sync.ts
+++ b/app/services/user-sync.ts
@@ -1,0 +1,93 @@
+import { getUserEvent, getUserOrganization } from './api/user';
+import { getActiveEvent, setActiveEvent } from './logged-in-event';
+import { getActiveOrganizationId, setActiveOrganization } from './logged-in-organization';
+
+export type RefreshUserAssignmentsResult = {
+  organizationChanged: boolean;
+  eventChanged: boolean;
+  organizationId: number | null;
+  eventCode: string | null;
+};
+
+const normalizeOrganizationId = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const extractOrganizationId = (
+  response: Awaited<ReturnType<typeof getUserOrganization>>,
+): number | null => {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+
+  const possibleValues = [
+    (response as { organizationId?: unknown }).organizationId,
+    (response as { organization_id?: unknown }).organization_id,
+  ];
+
+  for (const value of possibleValues) {
+    const normalized = normalizeOrganizationId(value);
+    if (normalized !== null) {
+      return normalized;
+    }
+  }
+
+  return null;
+};
+
+const extractEventCode = (response: Awaited<ReturnType<typeof getUserEvent>>): string | null => {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+
+  const rawEventCode = (response as { eventCode?: unknown }).eventCode;
+
+  if (typeof rawEventCode !== 'string') {
+    return null;
+  }
+
+  const trimmed = rawEventCode.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export async function refreshUserAssignmentsFromServer(): Promise<RefreshUserAssignmentsResult> {
+  const [organizationResponse, eventResponse] = await Promise.all([
+    getUserOrganization(),
+    getUserEvent(),
+  ]);
+
+  const remoteOrganizationId = extractOrganizationId(organizationResponse);
+  const remoteEventCode = extractEventCode(eventResponse);
+
+  const currentOrganizationId = getActiveOrganizationId();
+  const currentEventCode = getActiveEvent();
+
+  const organizationChanged = currentOrganizationId !== remoteOrganizationId;
+  const eventChanged = currentEventCode !== remoteEventCode;
+
+  if (organizationChanged) {
+    setActiveOrganization(remoteOrganizationId);
+  }
+
+  if (eventChanged) {
+    setActiveEvent(remoteEventCode);
+  }
+
+  return {
+    organizationChanged,
+    eventChanged,
+    organizationId: remoteOrganizationId,
+    eventCode: remoteEventCode,
+  };
+}


### PR DESCRIPTION
## Summary
- add a service to refresh the active organization/event from the `/user` API endpoints
- add a full-sync helper that refreshes general data and event info when the user assignment changes
- trigger the refresh and optional full sync whenever a session with an access token becomes available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe932f08c08326bc458e2102b1ce2b