### PR TITLE
Handle optional team names from team events

### DIFF
--- a/app/screens/Shared/TeamListScreen.tsx
+++ b/app/screens/Shared/TeamListScreen.tsx
@@ -89,11 +89,16 @@ export function TeamListScreen({ title, onTeamPress, showPitScoutingStatus = fal
       .all();
 
     const mapped = rows
-      .map((row) => ({
-        number: row.teamNumber,
-        name: row.teamName,
-        location: row.teamLocation ?? 'Location unavailable',
-      }))
+      .map((row) => {
+        const normalizedName =
+          typeof row.teamName === 'string' ? row.teamName.trim() : '';
+
+        return {
+          number: row.teamNumber,
+          name: normalizedName.length > 0 ? normalizedName : `Team ${row.teamNumber}`,
+          location: row.teamLocation ?? 'Location unavailable',
+        };
+      })
       .sort((a, b) => a.number - b.number);
 
     let alreadyScoutedTeams: number[] = [];

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -62,7 +62,7 @@ function initializeExpoSqliteDb() {
   const createStatements = [
     `CREATE TABLE IF NOT EXISTS teamrecord (
       team_number INTEGER PRIMARY KEY NOT NULL,
-      team_name TEXT NOT NULL,
+      team_name TEXT,
       location TEXT
     );`,
     `CREATE TABLE IF NOT EXISTS logged_in_event (

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -3,7 +3,7 @@ import { InferInsertModel, InferSelectModel, sql } from 'drizzle-orm';
 
 export const teamRecords = sqliteTable('teamrecord', {
   teamNumber: integer('team_number').primaryKey(),
-  teamName: text('team_name').notNull(),
+  teamName: text('team_name'),
   location: text('location'),
 });
 


### PR DESCRIPTION
## Summary
- allow team names from the API to be optional when normalizing and storing team records
- hydrate placeholders and existing teams with names provided by the team events endpoint when available
- fall back to a generic label when displaying teams without a stored name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe9522dd648326838bd5eaf826d92c