### PR TITLE
Handle robot photo storage fallback in Expo Go

### DIFF
--- a/src/services/photoStorage.ts
+++ b/src/services/photoStorage.ts
@@ -1,0 +1,35 @@
+import * as FileSystem from 'expo-file-system';
+
+export async function getWritableDirectory(): Promise<string | null> {
+  // eslint-disable-next-line import/namespace
+  const documentDirectory = FileSystem.documentDirectory ?? null;
+  // eslint-disable-next-line import/namespace
+  const cacheDirectory = FileSystem.cacheDirectory ?? null;
+
+  return documentDirectory ?? cacheDirectory ?? null;
+}
+
+function ensureTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+export async function copyPhotoToWritableDirectory(uri: string): Promise<string> {
+  const dir = await getWritableDirectory();
+
+  if (dir) {
+    const normalizedDir = ensureTrailingSlash(dir);
+    const filename = uri.split('/').pop() ?? `photo_${Date.now()}.jpg`;
+    const dest = `${normalizedDir}${filename}`;
+
+    try {
+      await FileSystem.copyAsync({ from: uri, to: dest });
+      return dest;
+    } catch (e) {
+      console.warn('Failed to copy file:', e);
+      return uri;
+    }
+  }
+
+  console.warn('No writable directory available — running in Expo Go?');
+  return uri;
+}


### PR DESCRIPTION
## Summary
- add a reusable photo storage helper that safely falls back to cache storage when documentDirectory is unavailable
- update robot photo capture to request media library permission, handle Expo Go fallbacks, and normalize storage paths
- reuse the new helper when resolving storage to keep Android SAF behavior while avoiding crashes on Expo Go

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe96e637188326a2587c65109ccf30