### PR TITLE
Add tablet-only Match Previews and SuperScout tabs

### DIFF
--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -1,15 +1,62 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'expo-router';
 import { Drawer } from 'expo-router/drawer';
 
 import { AppDrawerContent, type DrawerContentProps } from '@/components/layout/AppDrawerContent';
-import { DRAWER_ITEMS, useDrawerScreenOptions } from '@/app/navigation/drawer-items';
+import {
+  useDrawerItems,
+  useDrawerScreenOptions,
+  LANDSCAPE_DRAWER_ROUTE_PATHS,
+} from '@/app/navigation';
+import { useIsTablet } from '@/hooks/use-is-tablet';
+import {
+  lockOrientationAsync,
+  OrientationLock,
+  type OrientationLockValue,
+} from '@/lib/screen-orientation';
 
 export default function DrawerLayout() {
   const screenOptions = useDrawerScreenOptions();
+  const drawerItems = useDrawerItems();
+  const pathname = usePathname();
+  const isTablet = useIsTablet();
+  const lastOrientationLock = useRef<OrientationLockValue | null>(null);
+
+  useEffect(() => {
+    if (!isTablet) {
+      lastOrientationLock.current = null;
+      return;
+    }
+
+    let shouldLockLandscape = false;
+
+    if (pathname) {
+      for (const route of LANDSCAPE_DRAWER_ROUTE_PATHS) {
+        if (pathname.startsWith(route)) {
+          shouldLockLandscape = true;
+          break;
+        }
+      }
+    }
+    const desiredOrientation = shouldLockLandscape
+      ? OrientationLock.LANDSCAPE
+      : OrientationLock.PORTRAIT_UP;
+
+    if (lastOrientationLock.current === desiredOrientation) {
+      return;
+    }
+
+    lastOrientationLock.current = desiredOrientation;
+
+    void lockOrientationAsync(desiredOrientation).catch(() => {
+      lastOrientationLock.current = null;
+    });
+  }, [isTablet, pathname]);
 
   return (
     <Drawer drawerContent={(props: DrawerContentProps) => <AppDrawerContent {...props} />} screenOptions={screenOptions}>
-      {DRAWER_ITEMS.map((item) => (
+      {drawerItems.map((item) => (
         <Drawer.Screen
           key={item.name}
           name={item.name as never}

--- a/app/(drawer)/match-previews/index.tsx
+++ b/app/(drawer)/match-previews/index.tsx
@@ -1,0 +1,5 @@
+import { MatchPreviewsScreen } from '@/app/screens';
+
+export default function MatchPreviewsRoute() {
+  return <MatchPreviewsScreen />;
+}

--- a/app/(drawer)/super-scout/index.tsx
+++ b/app/(drawer)/super-scout/index.tsx
@@ -1,0 +1,5 @@
+import { SuperScoutScreen } from '@/app/screens';
+
+export default function SuperScoutRoute() {
+  return <SuperScoutScreen />;
+}

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -1,21 +1,25 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMemo } from 'react';
 import type { ComponentProps } from 'react';
 
 import { Colors } from '@/constants/theme';
 import { ROUTES } from '@/constants/routes';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useIsTablet } from '@/hooks/use-is-tablet';
 
 type IoniconName = ComponentProps<typeof Ionicons>['name'];
 
-export const DRAWER_ITEMS: {
+export type DrawerItem = {
   name: string;
   title: string;
   href: string;
   icon: IoniconName;
-}[] = [
+};
+
+const BASE_DRAWER_ITEMS: DrawerItem[] = [
   { name: 'pit-scout/index', title: 'Pit Scout', href: ROUTES.pitScout, icon: 'build-outline' },
   { name: 'match-scout/index', title: 'Match Scout', href: ROUTES.matchScout, icon: 'trophy-outline' },
-  { name: 'prescout/index', title: 'Prescout', href: ROUTES['prescout'], icon: 'search-outline' },
+  { name: 'prescout/index', title: 'Prescout', href: ROUTES.prescout, icon: 'search-outline' },
   { name: 'robot-photos/index', title: 'Robot Photos', href: ROUTES.robotPhotos, icon: 'camera-outline' },
   { name: 'settings/index', title: 'App Settings', href: ROUTES.appSettings, icon: 'settings-outline' },
   {
@@ -25,6 +29,48 @@ export const DRAWER_ITEMS: {
     icon: 'people-outline',
   },
 ];
+
+const TABLET_ONLY_DRAWER_ITEMS: DrawerItem[] = [
+  {
+    name: 'match-previews/index',
+    title: 'Match Previews',
+    href: ROUTES.matchPreviews,
+    icon: 'newspaper-outline',
+  },
+  {
+    name: 'super-scout/index',
+    title: 'SuperScout',
+    href: ROUTES.superScout,
+    icon: 'analytics-outline',
+  },
+];
+
+const LANDSCAPE_ROUTE_PREFIXES = TABLET_ONLY_DRAWER_ITEMS.map((item) => item.href);
+
+export const LANDSCAPE_DRAWER_ROUTE_PATHS = new Set(LANDSCAPE_ROUTE_PREFIXES);
+
+export function useDrawerItems() {
+  const isTablet = useIsTablet();
+
+  return useMemo(() => {
+    if (!isTablet) {
+      return BASE_DRAWER_ITEMS;
+    }
+
+    const items = [...BASE_DRAWER_ITEMS];
+    const insertIndex = items.findIndex((item) => item.name === 'match-scout/index');
+
+    const tabletItems = [...TABLET_ONLY_DRAWER_ITEMS];
+
+    if (insertIndex >= 0) {
+      items.splice(insertIndex + 1, 0, ...tabletItems);
+    } else {
+      items.push(...tabletItems);
+    }
+
+    return items;
+  }, [isTablet]);
+}
 
 export function useDrawerScreenOptions() {
   const colorScheme = useColorScheme();

--- a/app/navigation/index.ts
+++ b/app/navigation/index.ts
@@ -1,1 +1,6 @@
-export { DRAWER_ITEMS, useDrawerScreenOptions } from './drawer-items';
+export {
+  useDrawerItems,
+  useDrawerScreenOptions,
+  LANDSCAPE_DRAWER_ROUTE_PATHS,
+} from './drawer-items';
+export type { DrawerItem } from './drawer-items';

--- a/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
+++ b/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
@@ -1,0 +1,23 @@
+import { StyleSheet, View } from 'react-native';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+
+export function MatchPreviewsScreen() {
+  return (
+    <ScreenContainer>
+      <View style={styles.header}>
+        <ThemedText type="title">Match Previews</ThemedText>
+        <ThemedText type="subtitle">
+          Review upcoming match details and data to prepare your scouting strategy.
+        </ThemedText>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    gap: 8,
+  },
+});

--- a/app/screens/SuperScout/SuperScoutScreen.tsx
+++ b/app/screens/SuperScout/SuperScoutScreen.tsx
@@ -1,0 +1,23 @@
+import { StyleSheet, View } from 'react-native';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+
+export function SuperScoutScreen() {
+  return (
+    <ScreenContainer>
+      <View style={styles.header}>
+        <ThemedText type="title">SuperScout</ThemedText>
+        <ThemedText type="subtitle">
+          Capture alliance-wide performance insights while your team scouts each match.
+        </ThemedText>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    gap: 8,
+  },
+});

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -5,6 +5,8 @@ export { RobotPhotosScreen } from './RobotPhotos/RobotPhotosScreen';
 export { TeamRobotPhotosScreen } from './RobotPhotos/TeamRobotPhotosScreen';
 export { MatchScoutScreen } from './MatchScout/MatchScoutScreen';
 export { MatchTeamSelectScreen } from './MatchScout/MatchTeamSelectScreen';
+export { MatchPreviewsScreen } from './MatchPreviews/MatchPreviewsScreen';
+export { SuperScoutScreen } from './SuperScout/SuperScoutScreen';
 export { AppSettingsScreen } from './Settings/AppSettingsScreen';
 export { EventBrowserScreen } from './Settings/EventBrowserScreen';
 export { OrganizationApplyScreen } from './Settings/OrganizationApplyScreen';

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -3,7 +3,8 @@ import { router } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { Alert, Pressable, StyleSheet, View } from 'react-native';
 
-import { DRAWER_ITEMS } from '@/app/navigation';
+import { useDrawerItems } from '@/app/navigation';
+import type { DrawerItem } from '@/app/navigation';
 import { ROUTES } from '@/constants/routes';
 import { ThemedText } from '@/components/themed-text';
 import { Colors } from '@/constants/theme';
@@ -33,6 +34,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
   const { selectedOrganization, setSelectedOrganization } = useOrganization();
   const colorScheme = useColorScheme();
   const activeRouteName = state.routes[state.index]?.name;
+  const drawerItems = useDrawerItems();
   const tint = Colors[colorScheme].tint;
   const inactiveIconColor = Colors[colorScheme].icon;
   const activeItemBackground =
@@ -44,8 +46,8 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
     'settings/index',
     'organization-select/index',
   ]);
-  const primaryItems = DRAWER_ITEMS.filter((item) => !settingsItemNames.has(item.name));
-  const settingsItems = DRAWER_ITEMS.filter((item) => settingsItemNames.has(item.name));
+  const primaryItems = drawerItems.filter((item) => !settingsItemNames.has(item.name));
+  const settingsItems = drawerItems.filter((item) => settingsItemNames.has(item.name));
 
   const handleAuthAction = () => {
     navigation.closeDrawer();
@@ -64,7 +66,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
       : browsingLabel
     : browsingLabel;
 
-  const renderDrawerItem = (item: (typeof DRAWER_ITEMS)[number]) => {
+  const renderDrawerItem = (item: DrawerItem) => {
     const isActive = activeRouteName === item.name;
 
     return (

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -2,6 +2,8 @@ export const ROUTES = {
   login: '/auth/login' as const,
   pitScout: '/(drawer)/pit-scout' as const,
   matchScout: '/(drawer)/match-scout' as const,
+  matchPreviews: '/(drawer)/match-previews' as const,
+  superScout: '/(drawer)/super-scout' as const,
   prescout: '/(drawer)/prescout' as const,
   robotPhotos: '/(drawer)/robot-photos' as const,
   appSettings: '/(drawer)/settings' as const,

--- a/hooks/use-is-tablet.ts
+++ b/hooks/use-is-tablet.ts
@@ -1,0 +1,12 @@
+import { Platform, useWindowDimensions } from 'react-native';
+
+export function useIsTablet() {
+  const { width, height } = useWindowDimensions();
+  const smallestDimension = Math.min(width, height);
+
+  if (Platform.OS === 'ios') {
+    return Platform.isPad;
+  }
+
+  return smallestDimension >= 600;
+}

--- a/lib/screen-orientation.ts
+++ b/lib/screen-orientation.ts
@@ -1,0 +1,28 @@
+import { NativeModulesProxy } from 'expo-modules-core';
+
+export const OrientationLock = {
+  PORTRAIT_UP: 'PORTRAIT_UP',
+  LANDSCAPE: 'LANDSCAPE',
+} as const;
+
+export type OrientationLockValue = (typeof OrientationLock)[keyof typeof OrientationLock];
+
+const ExpoScreenOrientation =
+  NativeModulesProxy?.ExpoScreenOrientation as
+    | { lockAsync?: (orientation: OrientationLockValue) => Promise<void> }
+    | undefined;
+
+export async function lockOrientationAsync(lock: OrientationLockValue) {
+  if (!ExpoScreenOrientation?.lockAsync) {
+    const error = new Error('Screen orientation module is not available');
+    console.warn(error.message);
+    throw error;
+  }
+
+  try {
+    await ExpoScreenOrientation.lockAsync(lock);
+  } catch (error) {
+    console.warn('Failed to lock screen orientation', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add tablet detection and orientation locking that forces landscape on Match Previews and SuperScout for tablets
- add tablet-only Match Previews and SuperScout drawer entries with placeholder screens and routes
- update the drawer content to consume the dynamic drawer item list

## Testing
- npm run lint
- npx tsc --noEmit *(fails: existing type errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68fe9d548c6c8326a492a618865ac815