### PR TITLE
Set match scout as default landing screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,5 +3,5 @@ import { Redirect } from 'expo-router';
 import { ROUTES } from '@/constants/routes';
 
 export default function Index() {
-  return <Redirect href={ROUTES.pitScout} />;
+  return <Redirect href={ROUTES.matchScout} />;
 }


### PR DESCRIPTION
## Summary
- redirect the app entry route to the Match Scout screen so it is always the default on launch

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fea2e44f508326858d8f2ccb60208f