### PR TITLE
Add robot photo upload flow with sync fallback

### DIFF
--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -51,7 +51,7 @@ const showSyncSuccessAlert = (result: SyncDataWithServerResult) => {
 
   const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}`;
   const submissionSummary =
-    `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, and ${result.prescoutDataSent} prescout entries.`;
+    `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, and uploaded ${result.robotPhotosUploaded} robot photos.`;
   const title = result.eventChanged ? 'Event synchronized' : 'Sync complete';
   const message = [`Event: ${result.eventCode}`, submissionSummary, eventInfoSummary, alreadyScoutedSummary].join('\n\n');
 

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -3,3 +3,4 @@ export * from './client';
 export * from './ping';
 export * from './organizations';
 export * from './user';
+export * from './robot-photos';

--- a/app/services/api/robot-photos.ts
+++ b/app/services/api/robot-photos.ts
@@ -1,0 +1,124 @@
+import { apiRequest } from './client';
+
+export type RobotEventImageLinkResponse = {
+  id?: number;
+  teamNumber?: number;
+  eventKey?: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  image_url?: string | null;
+  url?: string | null;
+  publicUrl?: string | null;
+  public_url?: string | null;
+  remoteUrl?: string | null;
+  signedUrl?: string | null;
+  signed_url?: string | null;
+  image?: Record<string, unknown> | null;
+  data?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+const POSSIBLE_URL_KEYS = [
+  'remoteUrl',
+  'imageUrl',
+  'image_url',
+  'url',
+  'publicUrl',
+  'public_url',
+  'signedUrl',
+  'signed_url',
+];
+
+const normalizeFileUri = (uri: string) => {
+  if (/^file:\/\//i.test(uri) || /^content:\/\//i.test(uri)) {
+    return uri;
+  }
+
+  return `file://${uri.replace(/^\//, '')}`;
+};
+
+const tryExtractUrl = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return null;
+};
+
+const searchForUrl = (value: unknown, depth = 0): string | null => {
+  if (depth > 4) {
+    return null;
+  }
+
+  const direct = tryExtractUrl(value);
+
+  if (direct) {
+    return direct;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  for (const key of POSSIBLE_URL_KEYS) {
+    if (key in value) {
+      const nested = searchForUrl((value as Record<string, unknown>)[key], depth + 1);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  for (const nestedValue of Object.values(value as Record<string, unknown>)) {
+    const nested = searchForUrl(nestedValue, depth + 1);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+};
+
+export const extractRemoteUrlFromRobotPhotoResponse = (
+  response: RobotEventImageLinkResponse | null | undefined,
+): string | null => {
+  if (!response || typeof response !== 'object') {
+    return null;
+  }
+
+  return searchForUrl(response);
+};
+
+export async function uploadRobotPhoto(
+  teamNumber: number,
+  fileUri: string,
+  description?: string,
+): Promise<RobotEventImageLinkResponse> {
+  const formData = new FormData();
+  const normalizedUri = normalizeFileUri(fileUri);
+  const filename = fileUri.split('/').pop() ?? `robot_photo_${Date.now()}.jpg`;
+
+  formData.append(
+    'file',
+    {
+      uri: normalizedUri,
+      name: filename,
+      type: 'image/jpeg',
+    } as any,
+  );
+
+  if (description) {
+    formData.append('description', description);
+  }
+
+  return await apiRequest<RobotEventImageLinkResponse>(`/teams/${teamNumber}/images`, {
+    method: 'POST',
+    body: formData,
+  });
+}

--- a/app/services/robot-photos.ts
+++ b/app/services/robot-photos.ts
@@ -1,0 +1,30 @@
+import { eq } from 'drizzle-orm';
+
+import { getDbOrThrow, schema } from '@/db';
+import { tryUploadRobotPhotoRecord } from '@/src/services/robotPhotos';
+
+export async function syncPendingRobotPhotos(): Promise<number> {
+  const db = getDbOrThrow();
+  const rows = db
+    .select({
+      id: schema.robotPhotos.id,
+      eventKey: schema.robotPhotos.eventKey,
+      teamNumber: schema.robotPhotos.teamNumber,
+      localUri: schema.robotPhotos.localUri,
+    })
+    .from(schema.robotPhotos)
+    .where(eq(schema.robotPhotos.uploadPending, 1))
+    .all();
+
+  let uploaded = 0;
+
+  for (const row of rows) {
+    const success = await tryUploadRobotPhotoRecord(row);
+
+    if (success) {
+      uploaded += 1;
+    }
+  }
+
+  return uploaded;
+}

--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -4,6 +4,7 @@ import { retrieveEventInfo, type RetrieveEventInfoResult } from './event-info';
 import { getActiveEvent, setActiveEvent } from './logged-in-event';
 import { syncAlreadyScoutedEntries } from './already-scouted';
 import { syncAlreadyPitScoutedEntries } from './pit-scouting';
+import { syncPendingRobotPhotos } from './robot-photos';
 import { getDbOrThrow, schema } from '@/db';
 import { eq } from 'drizzle-orm';
 
@@ -16,6 +17,7 @@ export type SyncDataWithServerResult = {
   prescoutDataSent: number;
   alreadyScoutedUpdated: number;
   alreadyPitScoutedUpdated: number;
+  robotPhotosUploaded: number;
 };
 
 const normalizeEventCode = (rawEventCode: unknown): string | null => {
@@ -84,6 +86,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
 
   const alreadyScoutedUpdated = await syncAlreadyScoutedEntries(organizationId);
   const alreadyPitScoutedUpdated = await syncAlreadyPitScoutedEntries(organizationId);
+  const robotPhotosUploaded = await syncPendingRobotPhotos();
 
   return {
     eventCode: remoteEventCode,
@@ -94,5 +97,6 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
     prescoutDataSent: prescoutRows.length,
     alreadyScoutedUpdated,
     alreadyPitScoutedUpdated,
+    robotPhotosUploaded,
   };
 }


### PR DESCRIPTION
## Summary
- add an API client helper for uploading robot photos
- attempt an immediate robot photo upload after capture and record the result
- sync any pending robot photo uploads during the full data sync and report upload counts

## Testing
- npm run lint *(fails: existing expo-navigation-bar import resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6903eba1b010832681a6cf2371666619