### PR TITLE
Add SuperScout submission persistence and sync

### DIFF
--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -51,7 +51,7 @@ const showSyncSuccessAlert = (result: SyncDataWithServerResult) => {
 
   const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}`;
   const submissionSummary =
-    `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, and uploaded ${result.robotPhotosUploaded} robot photos.`;
+    `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, ${result.superScoutDataSent} SuperScout entries, and uploaded ${result.robotPhotosUploaded} robot photos.`;
   const superScoutSummary = `Super scout fields synced: ${result.superScoutFieldsSynced}`;
   const title = result.eventChanged ? 'Event synchronized' : 'Sync complete';
   const message = [

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -121,7 +121,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
 
       const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}`;
 
-      const submissionSummary = `Submitted ${result.matchDataSent} match entries and ${result.pitDataSent} pit entries.`;
+      const submissionSummary = `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, ${result.superScoutDataSent} SuperScout entries.`;
 
       const title = result.eventChanged ? 'Event synchronized' : 'Sync complete';
       const message = [`Event: ${result.eventCode}`, submissionSummary, eventInfoSummary, alreadyScoutedSummary].join('\n\n');

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -238,6 +238,22 @@ function initializeExpoSqliteDb() {
       key TEXT PRIMARY KEY NOT NULL,
       label TEXT NOT NULL
     );`,
+    `CREATE TABLE IF NOT EXISTS superscout_data (
+      event_key TEXT NOT NULL,
+      team_number INTEGER NOT NULL,
+      match_number INTEGER NOT NULL,
+      match_level TEXT NOT NULL,
+      alliance TEXT NOT NULL,
+      start_position TEXT,
+      notes TEXT,
+      driver_rating INTEGER NOT NULL DEFAULT 0,
+      robot_overall INTEGER NOT NULL DEFAULT 0,
+      defense_rating INTEGER,
+      submission_pending INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (event_key, team_number, match_number, match_level),
+      FOREIGN KEY (event_key) REFERENCES frcevent(event_key),
+      FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
+    );`,
     `CREATE TABLE IF NOT EXISTS superscout_selection (
       event_key TEXT NOT NULL,
       team_number INTEGER NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -413,6 +413,41 @@ export const superScoutFields = sqliteTable('superscout_field', {
 export type SuperScoutField = InferSelectModel<typeof superScoutFields>;
 export type NewSuperScoutField = InferInsertModel<typeof superScoutFields>;
 
+export const superScoutData = sqliteTable(
+  'superscout_data',
+  {
+    eventKey: text('event_key').notNull(),
+    teamNumber: integer('team_number').notNull(),
+    matchNumber: integer('match_number').notNull(),
+    matchLevel: text('match_level').notNull(),
+    alliance: text('alliance').notNull(),
+    startPosition: text('start_position'),
+    notes: text('notes'),
+    driverRating: integer('driver_rating').notNull().default(0),
+    robotOverall: integer('robot_overall').notNull().default(0),
+    defenseRating: integer('defense_rating'),
+    submissionPending: integer('submission_pending').notNull().default(1),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.eventKey, table.teamNumber, table.matchNumber, table.matchLevel],
+    }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'superscout_data_event_fk',
+    }),
+    teamRef: foreignKey({
+      columns: [table.teamNumber],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'superscout_data_team_fk',
+    }),
+  })
+);
+
+export type SuperScoutData = InferSelectModel<typeof superScoutData>;
+export type NewSuperScoutData = InferInsertModel<typeof superScoutData>;
+
 export const superScoutSelections = sqliteTable(
   'superscout_selection',
   {


### PR DESCRIPTION
## Summary
- add a superscout_data table and creation script to persist SuperScout form submissions along with canned comment selections
- implement confirmation, local storage, API submission, and navigation for the SuperScout match screen
- sync pending SuperScout submissions during data sync and include their counts in sync summaries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904cfc1524083269e20518a11959dc2