### PR TITLE
Add alliance-colored match descriptor badge

### DIFF
--- a/app/screens/SuperScout/SuperScoutMatchScreen.tsx
+++ b/app/screens/SuperScout/SuperScoutMatchScreen.tsx
@@ -691,9 +691,11 @@ export function SuperScoutMatchScreen({
         </Pressable>
 
         <View style={styles.matchDescriptor}>
-          <ThemedText type="title" style={[styles.matchSubtitle, { color: textColor }]}>
-            {matchLabel}: {allianceLabel}
-          </ThemedText>
+          <View style={[styles.matchBadge, { backgroundColor: allianceBackground }]}> 
+            <ThemedText type="title" style={[styles.matchSubtitle, { color: allianceText }]}> 
+              {matchLabel}: {allianceLabel}
+            </ThemedText>
+          </View>
         </View>
 
         <View style={styles.navButtonContainer}>
@@ -918,6 +920,11 @@ const styles = StyleSheet.create({
   matchDescriptor: {
     flex: 1,
     alignItems: 'center',
+  },
+  matchBadge: {
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
   },
   backButton: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- wrap the match descriptor in a badge that reflects the alliance color
- style the badge with rounded corners and alliance-colored text for readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904d510450c8326882da7a9d2063488