### PR TITLE
Add network-driven match preview schedule and detail view

### DIFF
--- a/app/(drawer)/match-previews/view.tsx
+++ b/app/(drawer)/match-previews/view.tsx
@@ -1,0 +1,14 @@
+import { useRouter, useLocalSearchParams } from 'expo-router';
+
+import {
+  MatchPreviewDetailsScreen,
+  createMatchPreviewDetailsScreenPropsFromParams,
+} from '@/app/screens/MatchPreviews/MatchPreviewDetailsScreen';
+
+export default function MatchPreviewDetailsRoute() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const screenProps = createMatchPreviewDetailsScreenPropsFromParams(params);
+
+  return <MatchPreviewDetailsScreen {...screenProps} onClose={() => router.back()} />;
+}

--- a/app/screens/MatchPreviews/MatchPreviewDetailsScreen.tsx
+++ b/app/screens/MatchPreviews/MatchPreviewDetailsScreen.tsx
@@ -1,0 +1,584 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import {
+  fetchMatchPreview,
+  type MatchPreviewResponse,
+  type MetricStatistics,
+} from '@/app/services/api/match-previews';
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export interface MatchPreviewDetailsScreenProps {
+  matchLevel?: string;
+  matchNumber?: number;
+  eventKey?: string;
+  red1?: number;
+  red2?: number;
+  red3?: number;
+  blue1?: number;
+  blue2?: number;
+  blue3?: number;
+  onClose: () => void;
+}
+
+const getMatchLevelLabel = (matchLevel: string | undefined) => {
+  const normalized = matchLevel?.toLowerCase();
+
+  switch (normalized) {
+    case 'qm':
+      return 'Qualification';
+    case 'sf':
+      return 'Playoff';
+    case 'qf':
+      return 'Quarterfinal';
+    case 'f':
+      return 'Final';
+    default:
+      return matchLevel?.toUpperCase() ?? 'Match';
+  }
+};
+
+const formatNumber = (value: number | null | undefined) => {
+  if (value === null || value === undefined || Number.isNaN(value) || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+};
+
+const formatStatWithDeviation = (stat?: MetricStatistics) => {
+  const average = formatNumber(stat?.average);
+
+  if (!average) {
+    return '—';
+  }
+
+  const deviation = formatNumber(stat?.standard_deviation);
+
+  if (deviation && deviation !== '0.0') {
+    return `${average} ±${deviation}`;
+  }
+
+  return average;
+};
+
+type AllianceTeam = MatchPreviewResponse['red']['teams'][number];
+
+const sumTeamAverages = (
+  teams: AllianceTeam[],
+  selector: (team: AllianceTeam) => MetricStatistics | undefined,
+) => {
+  let total = 0;
+  let hasValue = false;
+
+  teams.forEach((team) => {
+    const stat = selector(team);
+    const average = stat?.average;
+
+    if (average !== null && average !== undefined && Number.isFinite(average)) {
+      total += average;
+      hasValue = true;
+    }
+  });
+
+  return hasValue ? total : undefined;
+};
+
+const renderAllianceTeamNumbers = (fallback: (number | undefined)[], previewTeams: AllianceTeam[]) => {
+  if (previewTeams.length > 0) {
+    return previewTeams.map((team) => team.team_number).filter((team) => team !== undefined);
+  }
+
+  return fallback.filter((team) => team !== undefined);
+};
+
+export function MatchPreviewDetailsScreen({
+  matchLevel,
+  matchNumber,
+  eventKey,
+  red1,
+  red2,
+  red3,
+  blue1,
+  blue2,
+  blue3,
+  onClose,
+}: MatchPreviewDetailsScreenProps) {
+  const [preview, setPreview] = useState<MatchPreviewResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const accentColor = useThemeColor({ light: '#2563EB', dark: '#1E3A8A' }, 'tint');
+  const cardBackground = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
+  const borderColor = useThemeColor({ light: 'rgba(15, 23, 42, 0.1)', dark: 'rgba(148, 163, 184, 0.25)' }, 'text');
+  const mutedText = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.7)', dark: 'rgba(226, 232, 240, 0.7)' },
+    'text',
+  );
+  const textColor = useThemeColor({}, 'text');
+  const closeButtonBackground = useThemeColor({ light: '#E2E8F0', dark: '#1F2937' }, 'background');
+
+  const numericMatchNumber = Number.isFinite(matchNumber ?? NaN) ? matchNumber : undefined;
+  const hasValidParams = Boolean(matchLevel) && numericMatchNumber !== undefined;
+
+  const loadPreview = useCallback(async () => {
+    if (!matchLevel || numericMatchNumber === undefined) {
+      throw new Error('Match information is missing or invalid.');
+    }
+
+    return fetchMatchPreview({
+      matchLevel,
+      matchNumber: numericMatchNumber,
+      eventKey,
+    });
+  }, [eventKey, matchLevel, numericMatchNumber]);
+
+  const handlePreviewError = useCallback((error: unknown) => {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unable to load match preview information. Confirm you are connected to the internet and try again.';
+
+    setErrorMessage(message);
+    setPreview(null);
+  }, []);
+
+  useEffect(() => {
+    if (!hasValidParams) {
+      setIsLoading(false);
+      setErrorMessage('Match information is missing or invalid.');
+      setPreview(null);
+      return;
+    }
+
+    let isActive = true;
+    setIsLoading(true);
+
+    loadPreview()
+      .then((response) => {
+        if (!isActive) {
+          return;
+        }
+
+        setPreview(response);
+        setErrorMessage(null);
+      })
+      .catch((error) => {
+        if (!isActive) {
+          return;
+        }
+
+        handlePreviewError(error);
+      })
+      .finally(() => {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [handlePreviewError, hasValidParams, loadPreview]);
+
+  const handleRefresh = useCallback(() => {
+    if (isRefreshing || !hasValidParams) {
+      return;
+    }
+
+    setIsRefreshing(true);
+
+    loadPreview()
+      .then((response) => {
+        setPreview(response);
+        setErrorMessage(null);
+      })
+      .catch((error) => {
+        handlePreviewError(error);
+      })
+      .finally(() => {
+        setIsRefreshing(false);
+      });
+  }, [handlePreviewError, hasValidParams, isRefreshing, loadPreview]);
+
+  const matchLabel = useMemo(() => {
+    const levelLabel = getMatchLevelLabel(matchLevel);
+    if (!numericMatchNumber) {
+      return levelLabel;
+    }
+
+    return `${levelLabel} Match ${numericMatchNumber}`;
+  }, [matchLevel, numericMatchNumber]);
+
+  const redTeams = useMemo(
+    () => (preview?.red.teams ?? []) as AllianceTeam[],
+    [preview],
+  );
+  const blueTeams = useMemo(
+    () => (preview?.blue.teams ?? []) as AllianceTeam[],
+    [preview],
+  );
+
+  const redTeamNumbers = useMemo(
+    () => renderAllianceTeamNumbers([red1, red2, red3], redTeams),
+    [red1, red2, red3, redTeams],
+  );
+  const blueTeamNumbers = useMemo(
+    () => renderAllianceTeamNumbers([blue1, blue2, blue3], blueTeams),
+    [blue1, blue2, blue3, blueTeams],
+  );
+
+  const allianceSummaries = useMemo(() => {
+    if (!preview) {
+      return null;
+    }
+
+    const fields: {
+      key: string;
+      label: string;
+      selector: (team: AllianceTeam) => MetricStatistics | undefined;
+    }[] = [
+      { key: 'auto', label: 'Auto Total', selector: (team) => team.auto.total_points },
+      { key: 'teleop', label: 'Teleop Total', selector: (team) => team.teleop.total_points },
+      { key: 'endgame', label: 'Endgame', selector: (team) => team.endgame },
+      { key: 'total', label: 'Total Score', selector: (team) => team.total_points },
+    ];
+
+    return fields.map((field) => ({
+      key: field.key,
+      label: field.label,
+      red: formatNumber(sumTeamAverages(redTeams, field.selector)),
+      blue: formatNumber(sumTeamAverages(blueTeams, field.selector)),
+    }));
+  }, [blueTeams, preview, redTeams]);
+
+  const renderTeamCard = useCallback(
+    (team: AllianceTeam, alliance: 'red' | 'blue') => {
+      const cardBorder = alliance === 'red' ? '#DC2626' : '#2563EB';
+
+      return (
+        <View key={team.team_number} style={[styles.teamCard, { borderColor: cardBorder }]}>
+          <ThemedText type="defaultSemiBold" style={styles.teamCardTitle}>
+            Team {team.team_number}
+          </ThemedText>
+          <View style={styles.teamMetricsRow}>
+            <View style={styles.teamMetric}>
+              <ThemedText style={styles.metricLabel}>Auto</ThemedText>
+              <ThemedText style={styles.metricValue}>{formatStatWithDeviation(team.auto.total_points)}</ThemedText>
+            </View>
+            <View style={styles.teamMetric}>
+              <ThemedText style={styles.metricLabel}>Teleop</ThemedText>
+              <ThemedText style={styles.metricValue}>{formatStatWithDeviation(team.teleop.total_points)}</ThemedText>
+            </View>
+            <View style={styles.teamMetric}>
+              <ThemedText style={styles.metricLabel}>Endgame</ThemedText>
+              <ThemedText style={styles.metricValue}>{formatStatWithDeviation(team.endgame)}</ThemedText>
+            </View>
+            <View style={styles.teamMetric}>
+              <ThemedText style={styles.metricLabel}>Total</ThemedText>
+              <ThemedText style={styles.metricValue}>{formatStatWithDeviation(team.total_points)}</ThemedText>
+            </View>
+          </View>
+        </View>
+      );
+    },
+    [],
+  );
+
+  return (
+    <ScreenContainer>
+      <View style={styles.detailsHeader}>
+        <View style={styles.headerTextContainer}>
+          <ThemedText type="title">{matchLabel}</ThemedText>
+          {eventKey ? (
+            <ThemedText style={[styles.eventKeyLabel, { color: mutedText }]}>Event: {eventKey}</ThemedText>
+          ) : null}
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          onPress={onClose}
+          style={({ pressed }) => [
+            styles.closeButton,
+            {
+              backgroundColor: closeButtonBackground,
+              opacity: pressed ? 0.85 : 1,
+            },
+          ]}
+        >
+          <ThemedText style={styles.closeButtonText}>Close</ThemedText>
+        </Pressable>
+      </View>
+
+      <Pressable
+        accessibilityRole="button"
+        onPress={handleRefresh}
+        style={({ pressed }) => [
+          styles.refreshButton,
+          {
+            backgroundColor: accentColor,
+            opacity: pressed || isRefreshing ? 0.9 : 1,
+          },
+        ]}
+      >
+        {isRefreshing ? (
+          <ActivityIndicator color="#F8FAFC" />
+        ) : (
+          <ThemedText style={styles.refreshButtonText}>Refresh preview</ThemedText>
+        )}
+      </Pressable>
+
+      {isLoading ? (
+        <View style={styles.stateWrapper}>
+          <ActivityIndicator accessibilityLabel="Loading match preview" color={accentColor} />
+          <ThemedText style={[styles.stateMessage, { color: mutedText }]}>Loading match preview…</ThemedText>
+        </View>
+      ) : errorMessage ? (
+        <View style={[styles.stateCard, { backgroundColor: cardBackground, borderColor }]}>
+          <ThemedText type="defaultSemiBold" style={[styles.stateTitle, { color: textColor }]}>
+            Unable to load match preview
+          </ThemedText>
+          <ThemedText style={[styles.stateMessage, { color: mutedText }]}>{errorMessage}</ThemedText>
+        </View>
+      ) : preview ? (
+        <ScrollView contentContainerStyle={styles.previewContent}>
+          <View style={[styles.summaryCard, { backgroundColor: cardBackground, borderColor }]}
+          >
+            <ThemedText type="defaultSemiBold" style={styles.summaryTitle}>Alliance Summary</ThemedText>
+            <View style={styles.summaryHeaderRow}>
+              <ThemedText style={styles.summaryHeaderLabel}>Metric</ThemedText>
+              <View style={styles.summaryValuesHeader}>
+                <ThemedText style={[styles.summaryAllianceLabel, styles.redText]}>Red</ThemedText>
+                <ThemedText style={[styles.summaryAllianceLabel, styles.blueText]}>Blue</ThemedText>
+              </View>
+            </View>
+            {allianceSummaries?.map((field) => (
+              <View key={field.key} style={styles.summaryRow}>
+                <ThemedText style={styles.summaryLabel}>{field.label}</ThemedText>
+                <View style={styles.summaryValues}>
+                  <ThemedText style={[styles.summaryValue, styles.redText]}>
+                    {field.red ?? '—'}
+                  </ThemedText>
+                  <ThemedText style={[styles.summaryValue, styles.blueText]}>
+                    {field.blue ?? '—'}
+                  </ThemedText>
+                </View>
+              </View>
+            ))}
+          </View>
+
+          <View style={styles.teamListSection}>
+            <ThemedText type="defaultSemiBold" style={styles.sectionTitle}>
+              Red Alliance
+            </ThemedText>
+            <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>Teams: {redTeamNumbers.length > 0 ? redTeamNumbers.join(', ') : 'TBD'}</ThemedText>
+            <View style={styles.teamList}>{redTeams.map((team) => renderTeamCard(team, 'red'))}</View>
+          </View>
+
+          <View style={styles.teamListSection}>
+            <ThemedText type="defaultSemiBold" style={styles.sectionTitle}>
+              Blue Alliance
+            </ThemedText>
+            <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>Teams: {blueTeamNumbers.length > 0 ? blueTeamNumbers.join(', ') : 'TBD'}</ThemedText>
+            <View style={styles.teamList}>{blueTeams.map((team) => renderTeamCard(team, 'blue'))}</View>
+          </View>
+        </ScrollView>
+      ) : (
+        <View style={[styles.stateCard, { backgroundColor: cardBackground, borderColor }]}>
+          <ThemedText type="defaultSemiBold" style={[styles.stateTitle, { color: textColor }]}>
+            Match preview is not available for this match yet.
+          </ThemedText>
+        </View>
+      )}
+    </ScreenContainer>
+  );
+}
+
+export const createMatchPreviewDetailsScreenPropsFromParams = (params: {
+  matchLevel?: string | string[];
+  matchNumber?: string | string[];
+  eventKey?: string | string[];
+  red1?: string | string[];
+  red2?: string | string[];
+  red3?: string | string[];
+  blue1?: string | string[];
+  blue2?: string | string[];
+  blue3?: string | string[];
+}) => {
+  const toSingleValue = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value;
+
+  const parseNumber = (value: string | string[] | undefined) => {
+    const raw = toSingleValue(value);
+    if (!raw) {
+      return undefined;
+    }
+
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  };
+
+  return {
+    matchLevel: toSingleValue(params.matchLevel),
+    matchNumber: parseNumber(params.matchNumber),
+    eventKey: toSingleValue(params.eventKey),
+    red1: parseNumber(params.red1),
+    red2: parseNumber(params.red2),
+    red3: parseNumber(params.red3),
+    blue1: parseNumber(params.blue1),
+    blue2: parseNumber(params.blue2),
+    blue3: parseNumber(params.blue3),
+  };
+};
+
+const styles = StyleSheet.create({
+  detailsHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+    marginBottom: 16,
+  },
+  headerTextContainer: {
+    flex: 1,
+    gap: 4,
+  },
+  eventKeyLabel: {
+    fontSize: 14,
+  },
+  closeButton: {
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  closeButtonText: {
+    fontWeight: '600',
+  },
+  refreshButton: {
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    alignSelf: 'flex-start',
+    marginBottom: 16,
+  },
+  refreshButtonText: {
+    color: '#F8FAFC',
+    fontWeight: '600',
+  },
+  stateWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  stateCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 20,
+    gap: 12,
+  },
+  stateTitle: {
+    fontSize: 18,
+    textAlign: 'center',
+  },
+  stateMessage: {
+    textAlign: 'center',
+    fontSize: 16,
+  },
+  previewContent: {
+    gap: 20,
+    paddingBottom: 40,
+  },
+  summaryCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+    gap: 12,
+  },
+  summaryTitle: {
+    fontSize: 18,
+  },
+  summaryHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  summaryHeaderLabel: {
+    fontWeight: '600',
+  },
+  summaryValuesHeader: {
+    flexDirection: 'row',
+    gap: 24,
+  },
+  summaryAllianceLabel: {
+    fontWeight: '600',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(148, 163, 184, 0.3)',
+  },
+  summaryLabel: {
+    flex: 1,
+  },
+  summaryValues: {
+    flexDirection: 'row',
+    gap: 24,
+    minWidth: 160,
+    justifyContent: 'flex-end',
+  },
+  summaryValue: {
+    fontWeight: '600',
+  },
+  redText: {
+    color: '#DC2626',
+  },
+  blueText: {
+    color: '#2563EB',
+  },
+  teamListSection: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+  },
+  sectionSubtitle: {
+    fontSize: 15,
+  },
+  teamList: {
+    gap: 12,
+  },
+  teamCard: {
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: 14,
+    gap: 12,
+  },
+  teamCardTitle: {
+    fontSize: 16,
+  },
+  teamMetricsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  teamMetric: {
+    minWidth: 120,
+    gap: 4,
+  },
+  metricLabel: {
+    fontSize: 13,
+    color: 'rgba(15, 23, 42, 0.7)',
+  },
+  metricValue: {
+    fontWeight: '600',
+  },
+});

--- a/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
+++ b/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
@@ -1,23 +1,297 @@
-import { StyleSheet, View } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, View } from 'react-native';
 
+import { getActiveEvent } from '@/app/services/logged-in-event';
+import {
+  fetchMatchSchedule,
+  type MatchScheduleEntry as ApiMatchScheduleEntry,
+} from '@/app/services/api/match-previews';
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import {
+  MatchSchedule,
+  type MatchScheduleEntry,
+  type MatchScheduleSection,
+  MatchScheduleToggle,
+  SECTION_DEFINITIONS,
+  groupMatchesBySection,
+} from '@/components/match-schedule';
 import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+const SECTION_ORDER: MatchScheduleSection[] = ['qualification', 'playoffs', 'finals'];
+
+const mapScheduleEntry = (entry: ApiMatchScheduleEntry): MatchScheduleEntry => ({
+  match_number: entry.match_number,
+  match_level: entry.match_level,
+  event_key: entry.event_key,
+  red1_id: entry.red1_id ?? undefined,
+  red2_id: entry.red2_id ?? undefined,
+  red3_id: entry.red3_id ?? undefined,
+  blue1_id: entry.blue1_id ?? undefined,
+  blue2_id: entry.blue2_id ?? undefined,
+  blue3_id: entry.blue3_id ?? undefined,
+});
+
+const buildMatchRouteParams = (match: MatchScheduleEntry) => {
+  const params: Record<string, string> = {
+    matchLevel: match.match_level,
+    matchNumber: String(match.match_number),
+  };
+
+  const maybeAddTeam = (key: string, value: number | null | undefined) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      params[key] = String(value);
+    }
+  };
+
+  if (match.event_key) {
+    params.eventKey = match.event_key;
+  }
+
+  maybeAddTeam('red1', match.red1_id);
+  maybeAddTeam('red2', match.red2_id);
+  maybeAddTeam('red3', match.red3_id);
+  maybeAddTeam('blue1', match.blue1_id);
+  maybeAddTeam('blue2', match.blue2_id);
+  maybeAddTeam('blue3', match.blue3_id);
+
+  return params;
+};
 
 export function MatchPreviewsScreen() {
+  const router = useRouter();
+  const [selectedSection, setSelectedSection] = useState<MatchScheduleSection>('qualification');
+  const [matches, setMatches] = useState<MatchScheduleEntry[]>([]);
+  const [activeEventKey, setActiveEventKey] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const accentColor = useThemeColor({ light: '#2563EB', dark: '#1E3A8A' }, 'tint');
+  const cardBackground = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
+  const borderColor = useThemeColor({ light: 'rgba(15, 23, 42, 0.1)', dark: 'rgba(148, 163, 184, 0.25)' }, 'text');
+  const textColor = useThemeColor({}, 'text');
+  const mutedText = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.7)', dark: 'rgba(226, 232, 240, 0.7)' },
+    'text',
+  );
+
+  const loadSchedule = useCallback(async () => {
+    const eventKey = getActiveEvent();
+
+    if (!eventKey) {
+      throw new Error('No event is currently selected. Please select an event to view match previews.');
+    }
+
+    const response = await fetchMatchSchedule({ eventKey });
+    const normalizedMatches = (response ?? []).map(mapScheduleEntry);
+
+    return { eventKey, matches: normalizedMatches };
+  }, []);
+
+  const applyScheduleResult = useCallback(
+    (result: { eventKey: string; matches: MatchScheduleEntry[] }) => {
+      setActiveEventKey(result.eventKey);
+      setMatches(result.matches);
+      setErrorMessage(null);
+    },
+    [],
+  );
+
+  const handleScheduleError = useCallback((error: unknown) => {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'An unexpected error occurred while loading the match schedule.';
+
+    setErrorMessage(message);
+    setMatches([]);
+    setActiveEventKey(null);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true;
+
+      setIsLoading(true);
+
+      loadSchedule()
+        .then((result) => {
+          if (!isActive) {
+            return;
+          }
+
+          applyScheduleResult(result);
+        })
+        .catch((error) => {
+          if (!isActive) {
+            return;
+          }
+
+          handleScheduleError(error);
+        })
+        .finally(() => {
+          if (isActive) {
+            setIsLoading(false);
+          }
+        });
+
+      return () => {
+        isActive = false;
+      };
+    }, [applyScheduleResult, handleScheduleError, loadSchedule]),
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (isRefreshing) {
+      return;
+    }
+
+    setIsRefreshing(true);
+
+    loadSchedule()
+      .then((result) => {
+        applyScheduleResult(result);
+      })
+      .catch((error) => {
+        handleScheduleError(error);
+      })
+      .finally(() => {
+        setIsRefreshing(false);
+      });
+  }, [applyScheduleResult, handleScheduleError, isRefreshing, loadSchedule]);
+
+  useEffect(() => {
+    if (matches.length === 0) {
+      if (selectedSection !== 'qualification') {
+        setSelectedSection('qualification');
+      }
+      return;
+    }
+
+    const grouped = groupMatchesBySection(matches);
+    if (grouped[selectedSection].length === 0) {
+      const fallback = SECTION_ORDER.find((section) => grouped[section].length > 0);
+      if (fallback && fallback !== selectedSection) {
+        setSelectedSection(fallback);
+      }
+    }
+  }, [matches, selectedSection]);
+
+  const groupedMatches = useMemo(() => groupMatchesBySection(matches), [matches]);
+
+  const handleMatchPress = useCallback(
+    (match: MatchScheduleEntry) => {
+      const params = buildMatchRouteParams(match);
+      router.push({ pathname: '/(drawer)/match-previews/view', params });
+    },
+    [router],
+  );
+
+  const hasMatches = matches.length > 0;
+
   return (
     <ScreenContainer>
       <View style={styles.header}>
-        <ThemedText type="title">Match Previews</ThemedText>
-        <ThemedText type="subtitle">
-          Review upcoming match details and data to prepare your scouting strategy.
-        </ThemedText>
+        <View style={styles.headerTextContainer}>
+          <ThemedText type="title">Match Previews</ThemedText>
+          <ThemedText type="subtitle">
+            Browse the event match schedule and open a matchup to view its preview data.
+          </ThemedText>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          onPress={handleRefresh}
+          style={({ pressed }) => [
+            styles.refreshButton,
+            {
+              backgroundColor: accentColor,
+              opacity: pressed || isRefreshing ? 0.9 : 1,
+            },
+          ]}
+        >
+          {isRefreshing ? (
+            <ActivityIndicator color="#F8FAFC" />
+          ) : (
+            <ThemedText style={styles.refreshButtonText}>Refresh schedule</ThemedText>
+          )}
+        </Pressable>
       </View>
+
+      {isLoading ? (
+        <View style={styles.stateWrapper}>
+          <ActivityIndicator accessibilityLabel="Loading match schedule" color={accentColor} />
+          <ThemedText style={[styles.stateMessage, { color: mutedText }]}>Loading match schedule…</ThemedText>
+        </View>
+      ) : hasMatches ? (
+        <>
+          <MatchScheduleToggle
+            value={selectedSection}
+            onChange={setSelectedSection}
+            options={SECTION_DEFINITIONS}
+          />
+          <MatchSchedule matches={groupedMatches[selectedSection]} onMatchPress={handleMatchPress} />
+        </>
+      ) : (
+        <View style={[styles.stateCard, { backgroundColor: cardBackground, borderColor }]}>
+          <ThemedText type="defaultSemiBold" style={[styles.stateTitle, { color: textColor }]}>
+            {errorMessage ? 'Unable to load match schedule' : 'No match schedule available'}
+          </ThemedText>
+          <ThemedText style={[styles.stateMessage, { color: mutedText }]}>
+            {errorMessage
+              ? errorMessage
+              : activeEventKey
+              ? 'No matches are available for the selected event yet.'
+              : 'Select an event to load its match schedule.'}
+          </ThemedText>
+        </View>
+      )}
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
   header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 16,
+    marginBottom: 16,
+  },
+  headerTextContainer: {
+    flex: 1,
     gap: 8,
+  },
+  refreshButton: {
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+    minWidth: 140,
+  },
+  refreshButtonText: {
+    color: '#F8FAFC',
+    fontWeight: '600',
+  },
+  stateWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  stateCard: {
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 20,
+    gap: 12,
+  },
+  stateTitle: {
+    fontSize: 18,
+  },
+  stateMessage: {
+    textAlign: 'center',
+    fontSize: 16,
   },
 });

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -6,6 +6,7 @@ export { TeamRobotPhotosScreen } from './RobotPhotos/TeamRobotPhotosScreen';
 export { MatchScoutScreen } from './MatchScout/MatchScoutScreen';
 export { MatchTeamSelectScreen } from './MatchScout/MatchTeamSelectScreen';
 export { MatchPreviewsScreen } from './MatchPreviews/MatchPreviewsScreen';
+export { MatchPreviewDetailsScreen } from './MatchPreviews/MatchPreviewDetailsScreen';
 export { SuperScoutScreen } from './SuperScout/SuperScoutScreen';
 export { SuperScoutAllianceSelectScreen } from './SuperScout/SuperScoutAllianceSelectScreen';
 export { SuperScoutMatchScreen } from './SuperScout/SuperScoutMatchScreen';

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -4,3 +4,4 @@ export * from './ping';
 export * from './organizations';
 export * from './user';
 export * from './robot-photos';
+export * from './match-previews';

--- a/app/services/api/match-previews.ts
+++ b/app/services/api/match-previews.ts
@@ -1,0 +1,78 @@
+import { apiRequest, type ApiRequestParams } from './client';
+
+export interface MatchScheduleEntry {
+  event_key: string;
+  match_number: number;
+  match_level: string;
+  red1_id: number | null;
+  red2_id: number | null;
+  red3_id: number | null;
+  blue1_id: number | null;
+  blue2_id: number | null;
+  blue3_id: number | null;
+  season?: number | null;
+}
+
+export interface MetricStatistics {
+  average: number | null;
+  standard_deviation: number | null;
+}
+
+export interface PhaseMetrics {
+  level4: MetricStatistics;
+  level3: MetricStatistics;
+  level2: MetricStatistics;
+  level1: MetricStatistics;
+  net: MetricStatistics;
+  processor: MetricStatistics;
+  total_points: MetricStatistics;
+}
+
+export interface TeamMatchPreview {
+  team_number: number;
+  auto: PhaseMetrics;
+  teleop: PhaseMetrics;
+  endgame: MetricStatistics;
+  total_points: MetricStatistics;
+}
+
+export interface AllianceMatchPreview {
+  teams: TeamMatchPreview[];
+}
+
+export interface MatchPreviewResponse {
+  season: number;
+  red: AllianceMatchPreview;
+  blue: AllianceMatchPreview;
+}
+
+export interface FetchMatchScheduleParams {
+  eventKey?: string;
+}
+
+export const fetchMatchSchedule = (params?: FetchMatchScheduleParams) => {
+  const requestParams: ApiRequestParams | undefined = params?.eventKey
+    ? { eventKey: params.eventKey }
+    : undefined;
+
+  return apiRequest<MatchScheduleEntry[]>("/event/matches", {
+    method: 'GET',
+    params: requestParams,
+  });
+};
+
+export interface FetchMatchPreviewParams {
+  matchLevel: string;
+  matchNumber: number;
+  eventKey?: string;
+}
+
+export const fetchMatchPreview = ({ matchLevel, matchNumber, eventKey }: FetchMatchPreviewParams) => {
+  const normalizedLevel = matchLevel.toLowerCase();
+  const requestParams: ApiRequestParams | undefined = eventKey ? { eventKey } : undefined;
+
+  return apiRequest<MatchPreviewResponse>(
+    `/event/match/${encodeURIComponent(normalizedLevel)}/${matchNumber}/preview`,
+    { method: 'GET', params: requestParams }
+  );
+};


### PR DESCRIPTION
## Summary
- add an API client for loading match schedules and preview data over the network
- convert the match previews landing screen into a schedule browser with refresh controls
- add a match preview detail screen and route that surfaces alliance statistics for the selected match

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904d5fa23f4832691caacea76c1c15f