### PR TITLE
Add already super scouted syncing and update super scout schedule

### DIFF
--- a/app/screens/Settings/OrganizationSelectScreen.tsx
+++ b/app/screens/Settings/OrganizationSelectScreen.tsx
@@ -49,7 +49,7 @@ const showSyncSuccessAlert = (result: SyncDataWithServerResult) => {
     `Team list: received ${result.eventInfo.teamEvents.received}, created ${result.eventInfo.teamEvents.created}, removed ${result.eventInfo.teamEvents.removed}`,
   ].join('\n');
 
-  const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}`;
+  const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}, super ${result.alreadySuperScoutedUpdated}`;
   const submissionSummary =
     `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, ${result.superScoutDataSent} SuperScout entries, and uploaded ${result.robotPhotosUploaded} robot photos.`;
   const superScoutSummary = `Super scout fields synced: ${result.superScoutFieldsSynced}`;

--- a/app/services/already-super-scouted.ts
+++ b/app/services/already-super-scouted.ts
@@ -1,0 +1,146 @@
+import { apiRequest } from './api';
+import { getActiveEvent } from './logged-in-event';
+import { getDbOrThrow, schema } from '@/db';
+
+export type AlreadySuperScoutedResponse = {
+  eventCode?: string | null;
+  event_code?: string | null;
+  matchLevel?: string | null;
+  match_level?: string | null;
+  matchNumber?: number | string | null;
+  match_number?: number | string | null;
+  red?: boolean | string | number | null;
+  blue?: boolean | string | number | null;
+};
+
+const normalizeNumber = (value: number | string | null | undefined): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const toBoolean = (value: boolean | string | number | null | undefined): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (!normalized) {
+      return false;
+    }
+
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  return false;
+};
+
+export const normalizeAlreadySuperScouted = (
+  item: AlreadySuperScoutedResponse,
+): typeof schema.alreadySuperScouteds.$inferInsert[] => {
+  const eventCodeRaw =
+    typeof item.eventCode === 'string'
+      ? item.eventCode
+      : typeof item.event_code === 'string'
+      ? item.event_code
+      : '';
+  const matchLevelRaw =
+    typeof item.matchLevel === 'string'
+      ? item.matchLevel
+      : typeof item.match_level === 'string'
+      ? item.match_level
+      : '';
+
+  const eventCode = eventCodeRaw.trim();
+  const matchLevel = matchLevelRaw.trim();
+  const matchNumber = normalizeNumber(item.matchNumber ?? item.match_number ?? null);
+
+  if (!eventCode || !matchLevel || matchNumber === null) {
+    return [];
+  }
+
+  const entries: typeof schema.alreadySuperScouteds.$inferInsert[] = [];
+
+  if (toBoolean(item.red ?? null)) {
+    entries.push({ eventCode, matchLevel, matchNumber, alliance: 'red' });
+  }
+
+  if (toBoolean(item.blue ?? null)) {
+    entries.push({ eventCode, matchLevel, matchNumber, alliance: 'blue' });
+  }
+
+  return entries;
+};
+
+export async function syncAlreadySuperScoutedEntries(
+  eventCode?: string | null,
+): Promise<number> {
+  const resolvedEventCode = eventCode ?? getActiveEvent();
+
+  if (!resolvedEventCode) {
+    return 0;
+  }
+
+  const response = await apiRequest<AlreadySuperScoutedResponse[]>('/scout/superscouted', {
+    method: 'GET',
+  });
+
+  const entries = Array.isArray(response)
+    ? response
+        .flatMap((item) => normalizeAlreadySuperScouted(item))
+        .filter((entry) => entry.eventCode === resolvedEventCode)
+    : [];
+
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  const uniqueEntries = new Map<string, typeof schema.alreadySuperScouteds.$inferInsert>();
+
+  for (const entry of entries) {
+    const key = `${entry.eventCode}#${entry.matchLevel}#${entry.matchNumber}#${entry.alliance}`;
+
+    if (!uniqueEntries.has(key)) {
+      uniqueEntries.set(key, entry);
+    }
+  }
+
+  const db = getDbOrThrow();
+
+  return db.transaction((tx) => {
+    let inserted = 0;
+
+    for (const entry of uniqueEntries.values()) {
+      const result = tx
+        .insert(schema.alreadySuperScouteds)
+        .values(entry)
+        .onConflictDoNothing()
+        .run();
+
+      if (result.rowsAffected > 0) {
+        inserted += 1;
+      }
+    }
+
+    return inserted;
+  });
+}

--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -18,6 +18,7 @@ export type SyncDataWithServerResult = {
   superScoutDataSent: number;
   alreadyScoutedUpdated: number;
   alreadyPitScoutedUpdated: number;
+  alreadySuperScoutedUpdated: number;
   robotPhotosUploaded: number;
   superScoutFieldsSynced: number;
 };
@@ -275,6 +276,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
 
   const alreadyScoutedUpdated = await syncAlreadyScoutedEntries(organizationId);
   const alreadyPitScoutedUpdated = await syncAlreadyPitScoutedEntries(organizationId);
+  const alreadySuperScoutedUpdated = eventInfo.alreadySuperScouted.created;
   const robotPhotosUploaded = await syncPendingRobotPhotos();
 
   return {
@@ -287,6 +289,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
     superScoutDataSent,
     alreadyScoutedUpdated,
     alreadyPitScoutedUpdated,
+    alreadySuperScoutedUpdated,
     robotPhotosUploaded,
     superScoutFieldsSynced,
   };

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -119,7 +119,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
         `Team list: received ${result.eventInfo.teamEvents.received}, created ${result.eventInfo.teamEvents.created}, removed ${result.eventInfo.teamEvents.removed}`,
       ].join('\n');
 
-      const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}`;
+      const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}, super ${result.alreadySuperScoutedUpdated}`;
 
       const submissionSummary = `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, ${result.superScoutDataSent} SuperScout entries.`;
 

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -211,6 +211,14 @@ function initializeExpoSqliteDb() {
       FOREIGN KEY (team_number) REFERENCES teamrecord(team_number),
       FOREIGN KEY (organization_id) REFERENCES organization(id)
     );`,
+    `CREATE TABLE IF NOT EXISTS already_super_scouted (
+      event_code TEXT NOT NULL,
+      match_level TEXT NOT NULL,
+      match_number INTEGER NOT NULL,
+      alliance TEXT NOT NULL CHECK (alliance IN ('red', 'blue')),
+      PRIMARY KEY (event_code, match_level, match_number, alliance),
+      FOREIGN KEY (event_code) REFERENCES frcevent(event_key)
+    );`,
     `CREATE TABLE IF NOT EXISTS prescoutmatchdata2025 (
       event_key TEXT NOT NULL,
       team_number INTEGER NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -361,6 +361,29 @@ export const alreadyPitScouteds = sqliteTable(
 export type AlreadyPitScouted = InferSelectModel<typeof alreadyPitScouteds>;
 export type NewAlreadyPitScouted = InferInsertModel<typeof alreadyPitScouteds>;
 
+export const alreadySuperScouteds = sqliteTable(
+  'already_super_scouted',
+  {
+    eventCode: text('event_code').notNull(),
+    matchLevel: text('match_level').notNull(),
+    matchNumber: integer('match_number').notNull(),
+    alliance: text('alliance', { enum: ['red', 'blue'] }).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.eventCode, table.matchLevel, table.matchNumber, table.alliance],
+    }),
+    eventRef: foreignKey({
+      columns: [table.eventCode],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'already_super_scouted_event_fk',
+    }),
+  })
+);
+
+export type AlreadySuperScouted = InferSelectModel<typeof alreadySuperScouteds>;
+export type NewAlreadySuperScouted = InferInsertModel<typeof alreadySuperScouteds>;
+
 export const prescoutMatchData2025 = sqliteTable(
   'prescoutmatchdata2025',
   {


### PR DESCRIPTION
## Summary
- add an already_super_scouted table and sync helpers for storing superscouted matches
- extend event info retrieval and sync summaries to include superscouted data
- update the Super Scout landing screen to gray and group matches when both alliances are superscouted locally or remotely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904d90f899c8326bcb65139dfa5cb73