### PR TITLE
Add Pick Lists placeholder screen

### DIFF
--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -9,6 +9,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useAuth } from '../hooks/useAuth';
 import LoginScreen from '../screens/LoginScreen';
+import PickListsScreen from '../screens/PickListsScreen';
 
 const Drawer = createDrawerNavigator();
 
@@ -87,6 +88,13 @@ const DrawerNavigator = () => {
       )}
     >
       <Drawer.Screen name="Home" component={HomeScreen} />
+      <Drawer.Screen
+        name="PickLists"
+        component={PickListsScreen}
+        options={{
+          title: 'Pick Lists',
+        }}
+      />
       <Drawer.Screen
         name="Login"
         component={LoginScreen}

--- a/src/screens/PickListsScreen.tsx
+++ b/src/screens/PickListsScreen.tsx
@@ -1,0 +1,29 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+const PickListsScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Pick Lists</Text>
+    <Text style={styles.subtitle}>This feature is coming soon.</Text>
+  </View>
+);
+
+export default PickListsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#4a4a4a',
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add a placeholder Pick Lists screen
- register the Pick Lists screen in the app drawer with a friendly title

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904f650840c8326820105199bff48bb