### PR TITLE
Add my matches tab to match previews

### DIFF
--- a/components/match-schedule/constants.ts
+++ b/components/match-schedule/constants.ts
@@ -1,6 +1,6 @@
 import type { MatchScheduleEntry } from './types';
 
-export type MatchScheduleSection = 'qualification' | 'playoffs' | 'finals';
+export type MatchScheduleSection = 'qualification' | 'playoffs' | 'finals' | 'my-matches';
 
 export interface MatchScheduleToggleOption {
   label: string;
@@ -21,6 +21,7 @@ export const groupMatchesBySection = (matches: MatchScheduleEntry[]) => {
     qualification: [],
     playoffs: [],
     finals: [],
+    'my-matches': [],
   };
 
   matches.forEach((match) => {


### PR DESCRIPTION
## Summary
- add a My Matches tab to the match previews toggle
- filter matches for the logged-in organization and sort unplayed matches first
- extend match schedule grouping to recognize the new section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904f625dd98832699a0747dcef13784