### PR TITLE
Preserve my matches ordering in schedule list

### DIFF
--- a/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
+++ b/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
@@ -312,12 +312,16 @@ export function MatchPreviewsScreen() {
               <ThemedText type="defaultSemiBold" style={[styles.stateTitle, { color: textColor }]}>
                 Select an organization to view your matches
               </ThemedText>
-              <ThemedText style={[styles.stateMessage, { color: mutedText }]}> 
+              <ThemedText style={[styles.stateMessage, { color: mutedText }]}>
                 Choose an organization with a team number to filter matches assigned to your team.
               </ThemedText>
             </View>
           ) : (
-            <MatchSchedule matches={selectedMatches} onMatchPress={handleMatchPress} />
+            <MatchSchedule
+              matches={selectedMatches}
+              onMatchPress={handleMatchPress}
+              preserveMatchOrder={selectedSection === 'my-matches'}
+            />
           )}
         </>
       ) : (


### PR DESCRIPTION
## Summary
- add a preserveMatchOrder flag to the match schedule component so the caller can retain custom sort order
- ensure the My Matches tab keeps its played and level-based ordering by enabling the flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904fa6834a0832682637c5a5818a661