### PR TITLE
Default match previews to My Matches tab

### DIFF
--- a/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
+++ b/app/screens/MatchPreviews/MatchPreviewsScreen.tsx
@@ -94,7 +94,7 @@ const buildMatchRouteParams = (match: MatchScheduleEntry) => {
 
 export function MatchPreviewsScreen() {
   const router = useRouter();
-  const [selectedSection, setSelectedSection] = useState<MatchScheduleSection>('qualification');
+  const [selectedSection, setSelectedSection] = useState<MatchScheduleSection>('my-matches');
   const [matches, setMatches] = useState<MatchScheduleEntry[]>([]);
   const [activeEventKey, setActiveEventKey] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -265,14 +265,17 @@ export function MatchPreviewsScreen() {
 
   useEffect(() => {
     if (matches.length === 0) {
-      if (selectedSection !== 'qualification') {
-        setSelectedSection('qualification');
+      if (selectedSection !== 'my-matches') {
+        setSelectedSection('my-matches');
       }
       return;
     }
 
     const currentSectionMatches = groupedMatches[selectedSection];
     if (currentSectionMatches.length === 0) {
+      if (selectedSection === 'my-matches') {
+        return;
+      }
       const fallback = SECTION_ORDER.find((section) => groupedMatches[section].length > 0);
       if (fallback && fallback !== selectedSection) {
         setSelectedSection(fallback);


### PR DESCRIPTION
## Summary
- set the My Matches section as the initial tab when viewing match previews
- prevent the automatic fallback from switching away from My Matches so users see their prompt or matches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904fc17accc8326af2239c8c57131dd