### PR TITLE
Add Pick Lists tab to drawer navigation

### DIFF
--- a/app/(drawer)/pick-lists/index.tsx
+++ b/app/(drawer)/pick-lists/index.tsx
@@ -1,0 +1,5 @@
+import { PickListsScreen } from '@/app/screens';
+
+export default function PickListsRoute() {
+  return <PickListsScreen />;
+}

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -21,6 +21,7 @@ const BASE_DRAWER_ITEMS: DrawerItem[] = [
   { name: 'match-scout/index', title: 'Match Scout', href: ROUTES.matchScout, icon: 'trophy-outline' },
   { name: 'prescout/index', title: 'Prescout', href: ROUTES.prescout, icon: 'search-outline' },
   { name: 'robot-photos/index', title: 'Robot Photos', href: ROUTES.robotPhotos, icon: 'camera-outline' },
+  { name: 'pick-lists/index', title: 'Pick Lists', href: ROUTES.pickLists, icon: 'list-outline' },
   { name: 'settings/index', title: 'App Settings', href: ROUTES.appSettings, icon: 'settings-outline' },
   {
     name: 'organization-select/index',

--- a/app/screens/PickLists/PickListsScreen.tsx
+++ b/app/screens/PickLists/PickListsScreen.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet, View } from 'react-native';
+
+import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+export function PickListsScreen() {
+  const accentColor = useThemeColor({ light: '#0a7ea4', dark: '#7cd4f7' }, 'tint');
+  const subtitleColor = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.7)', dark: 'rgba(226, 232, 240, 0.7)' },
+    'text',
+  );
+
+  return (
+    <ScreenContainer>
+      <View style={styles.content}>
+        <ThemedText type="title" style={[styles.title, { color: accentColor }]}>
+          Pick Lists
+        </ThemedText>
+        <ThemedText style={[styles.subtitle, { color: subtitleColor }]}>
+          This feature is coming soon.
+        </ThemedText>
+      </View>
+    </ScreenContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 12,
+  },
+  title: {
+    textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+  },
+});

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -10,6 +10,7 @@ export { MatchPreviewDetailsScreen } from './MatchPreviews/MatchPreviewDetailsSc
 export { SuperScoutScreen } from './SuperScout/SuperScoutScreen';
 export { SuperScoutAllianceSelectScreen } from './SuperScout/SuperScoutAllianceSelectScreen';
 export { SuperScoutMatchScreen } from './SuperScout/SuperScoutMatchScreen';
+export { PickListsScreen } from './PickLists/PickListsScreen';
 export { AppSettingsScreen } from './Settings/AppSettingsScreen';
 export { EventBrowserScreen } from './Settings/EventBrowserScreen';
 export { OrganizationApplyScreen } from './Settings/OrganizationApplyScreen';

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   matchScout: '/(drawer)/match-scout' as const,
   matchPreviews: '/(drawer)/match-previews' as const,
   superScout: '/(drawer)/super-scout' as const,
+  pickLists: '/(drawer)/pick-lists' as const,
   prescout: '/(drawer)/prescout' as const,
   robotPhotos: '/(drawer)/robot-photos' as const,
   appSettings: '/(drawer)/settings' as const,


### PR DESCRIPTION
## Summary
- add a Pick Lists route and include it in the Expo Router drawer configuration
- implement a placeholder Pick Lists screen within the new app/screens structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690502b5c15c83268840b17935ad0d46