### PR TITLE
Restrict pick lists to lead and admin roles

### DIFF
--- a/app/(drawer)/pick-lists/index.tsx
+++ b/app/(drawer)/pick-lists/index.tsx
@@ -1,5 +1,27 @@
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+
 import { PickListsScreen } from '@/app/screens';
+import { ROUTES } from '@/constants/routes';
+import { useOrganizationRole } from '@/hooks/use-organization-role';
 
 export default function PickListsRoute() {
+  const router = useRouter();
+  const { canManagePickLists, isLoading } = useOrganizationRole();
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    if (!canManagePickLists) {
+      router.replace(ROUTES.pitScout);
+    }
+  }, [canManagePickLists, isLoading, router]);
+
+  if (isLoading || !canManagePickLists) {
+    return null;
+  }
+
   return <PickListsScreen />;
 }

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -6,6 +6,7 @@ import { Colors } from '@/constants/theme';
 import { ROUTES } from '@/constants/routes';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useIsTablet } from '@/hooks/use-is-tablet';
+import { useOrganizationRole } from '@/hooks/use-organization-role';
 
 type IoniconName = ComponentProps<typeof Ionicons>['name'];
 
@@ -52,10 +53,14 @@ export const LANDSCAPE_DRAWER_ROUTE_PATHS = new Set(LANDSCAPE_ROUTE_PREFIXES);
 
 export function useDrawerItems() {
   const isTablet = useIsTablet();
+  const { canManagePickLists } = useOrganizationRole();
 
   return useMemo(() => {
+    const pickListFilter = (item: DrawerItem) =>
+      canManagePickLists || item.name !== 'pick-lists/index';
+
     if (!isTablet) {
-      return BASE_DRAWER_ITEMS;
+      return BASE_DRAWER_ITEMS.filter(pickListFilter);
     }
 
     const items = [...BASE_DRAWER_ITEMS];
@@ -69,8 +74,8 @@ export function useDrawerItems() {
       items.push(...tabletItems);
     }
 
-    return items;
-  }, [isTablet]);
+    return items.filter(pickListFilter);
+  }, [canManagePickLists, isTablet]);
 }
 
 export function useDrawerScreenOptions() {

--- a/hooks/use-organization-role.ts
+++ b/hooks/use-organization-role.ts
@@ -1,0 +1,79 @@
+import { useEffect, useMemo, useState } from 'react';
+import { eq } from 'drizzle-orm';
+
+import { getDbOrThrow, schema } from '@/db';
+import { useOrganization } from '@/hooks/use-organization';
+
+function normalizeRole(role: unknown): string | null {
+  if (typeof role !== 'string') {
+    return null;
+  }
+
+  const trimmed = role.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed.toUpperCase();
+}
+
+export function useOrganizationRole() {
+  const { selectedOrganization } = useOrganization();
+  const [role, setRole] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadRole = () => {
+      setIsLoading(true);
+
+      if (!selectedOrganization) {
+        setRole(null);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const db = getDbOrThrow();
+        const records = db
+          .select({ role: schema.userOrganizations.role })
+          .from(schema.userOrganizations)
+          .where(eq(schema.userOrganizations.organizationId, selectedOrganization.id))
+          .limit(1)
+          .all();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setRole(normalizeRole(records[0]?.role));
+        setIsLoading(false);
+      } catch (error) {
+        console.warn('Failed to read organization role from database', error);
+        if (!isMounted) {
+          return;
+        }
+        setRole(null);
+        setIsLoading(false);
+      }
+    };
+
+    loadRole();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedOrganization?.id]);
+
+  const permissions = useMemo(
+    () => ({
+      role,
+      canManagePickLists: role === 'ADMIN' || role === 'LEAD',
+      isLoading,
+    }),
+    [isLoading, role],
+  );
+
+  return permissions;
+}


### PR DESCRIPTION
## Summary
- add a hook to read the active organization role and expose pick-list access
- hide the Pick Lists drawer item unless the user is an admin or lead
- block navigation to the Pick Lists route for users without access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69051143557c8326962a920764aca50d