### PR TITLE
feat: add tablet-only pick list viewer

### DIFF
--- a/app/(drawer)/pick-lists/index.tsx
+++ b/app/(drawer)/pick-lists/index.tsx
@@ -3,23 +3,25 @@ import { useRouter } from 'expo-router';
 
 import { PickListsScreen } from '@/app/screens';
 import { ROUTES } from '@/constants/routes';
+import { useIsTablet } from '@/hooks/use-is-tablet';
 import { useOrganizationRole } from '@/hooks/use-organization-role';
 
 export default function PickListsRoute() {
   const router = useRouter();
   const { canManagePickLists, isLoading } = useOrganizationRole();
+  const isTablet = useIsTablet();
 
   useEffect(() => {
     if (isLoading) {
       return;
     }
 
-    if (!canManagePickLists) {
+    if (!canManagePickLists || !isTablet) {
       router.replace(ROUTES.pitScout);
     }
-  }, [canManagePickLists, isLoading, router]);
+  }, [canManagePickLists, isLoading, isTablet, router]);
 
-  if (isLoading || !canManagePickLists) {
+  if (isLoading || !canManagePickLists || !isTablet) {
     return null;
   }
 

--- a/app/navigation/drawer-items.ts
+++ b/app/navigation/drawer-items.ts
@@ -22,7 +22,6 @@ const BASE_DRAWER_ITEMS: DrawerItem[] = [
   { name: 'match-scout/index', title: 'Match Scout', href: ROUTES.matchScout, icon: 'trophy-outline' },
   { name: 'prescout/index', title: 'Prescout', href: ROUTES.prescout, icon: 'search-outline' },
   { name: 'robot-photos/index', title: 'Robot Photos', href: ROUTES.robotPhotos, icon: 'camera-outline' },
-  { name: 'pick-lists/index', title: 'Pick Lists', href: ROUTES.pickLists, icon: 'list-outline' },
   { name: 'settings/index', title: 'App Settings', href: ROUTES.appSettings, icon: 'settings-outline' },
   {
     name: 'organization-select/index',
@@ -33,6 +32,12 @@ const BASE_DRAWER_ITEMS: DrawerItem[] = [
 ];
 
 const TABLET_ONLY_DRAWER_ITEMS: DrawerItem[] = [
+  {
+    name: 'pick-lists/index',
+    title: 'Pick Lists',
+    href: ROUTES.pickLists,
+    icon: 'list-outline',
+  },
   {
     name: 'match-previews/index',
     title: 'Match Previews',

--- a/app/screens/PickLists/PickListsScreen.tsx
+++ b/app/screens/PickLists/PickListsScreen.tsx
@@ -1,42 +1,657 @@
-import { StyleSheet, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useQuery } from '@tanstack/react-query';
+import { Stack } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 
+import { fetchEventTeams, fetchOrganizationEvents } from '@/app/services/api/events';
+import type { EventTeam, OrganizationEvent } from '@/app/services/api/events';
+import { fetchPickLists } from '@/app/services/api/pick-lists';
+import type { PickList, PickListRank } from '@/app/services/api/pick-lists';
+import { getActiveEvent } from '@/app/services/logged-in-event';
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
+import { PickListPreview } from '@/components/pick-lists/PickListPreview';
 import { ThemedText } from '@/components/themed-text';
+import { useOrganization } from '@/hooks/use-organization';
 import { useThemeColor } from '@/hooks/use-theme-color';
 
+const DEFAULT_ALLIANCE_COUNT = 8;
+
+type AllianceRecommendation = {
+  captain: PickListRank | null;
+  firstPick: PickListRank | null;
+  secondPick: PickListRank | null;
+  thirdPick: PickListRank | null;
+};
+
+const getTimestamp = (value: string | null | undefined) => {
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+const buildAllianceRecommendations = (
+  ranks: PickListRank[],
+  allianceCount: number,
+): AllianceRecommendation[] => {
+  const available = ranks.filter((rank) => !rank.dnp);
+  const count = Math.min(allianceCount, available.length);
+
+  if (count === 0) {
+    return [];
+  }
+
+  const alliances: AllianceRecommendation[] = Array.from({ length: count }, () => ({
+    captain: null,
+    firstPick: null,
+    secondPick: null,
+    thirdPick: null,
+  }));
+
+  for (let index = 0; index < available.length; index += 1) {
+    const allianceIndex = index % count;
+    const round = Math.floor(index / count);
+    const targetAlliance = alliances[allianceIndex];
+
+    if (round === 0) {
+      targetAlliance.captain ??= available[index];
+      continue;
+    }
+
+    if (round === 1) {
+      targetAlliance.firstPick ??= available[index];
+      continue;
+    }
+
+    if (round === 2) {
+      targetAlliance.secondPick ??= available[index];
+      continue;
+    }
+
+    if (round === 3) {
+      targetAlliance.thirdPick ??= available[index];
+      continue;
+    }
+
+    break;
+  }
+
+  return alliances;
+};
+
 export function PickListsScreen() {
+  const { selectedOrganization } = useOrganization();
+  const [selectedPickListId, setSelectedPickListId] = useState<string | null>(null);
+  const [localActiveEventKey] = useState<string | null>(() => getActiveEvent());
+
   const accentColor = useThemeColor({ light: '#0a7ea4', dark: '#7cd4f7' }, 'tint');
-  const subtitleColor = useThemeColor(
-    { light: 'rgba(15, 23, 42, 0.7)', dark: 'rgba(226, 232, 240, 0.7)' },
+  const textColor = useThemeColor({}, 'text');
+  const cardBackground = useThemeColor({ light: '#FFFFFF', dark: '#111827' }, 'background');
+  const borderColor = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.12)', dark: 'rgba(148, 163, 184, 0.28)' },
     'text',
+  );
+  const mutedText = useThemeColor({ light: '#475569', dark: '#94A3B8' }, 'text');
+  const chipBackground = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.05)', dark: 'rgba(148, 163, 184, 0.15)' },
+    'text',
+  );
+  const chipSelectedBackground = useThemeColor(
+    { light: 'rgba(14, 165, 233, 0.14)', dark: 'rgba(56, 189, 248, 0.2)' },
+    'tint',
+  );
+  const errorColor = useThemeColor({ light: '#dc2626', dark: '#fca5a5' }, 'text');
+
+  const {
+    data: organizationEvents = [],
+    isLoading: isLoadingEvents,
+    isError: isEventsError,
+    error: organizationEventsError,
+  } = useQuery<OrganizationEvent[]>(
+    {
+      queryKey: ['organization-events', selectedOrganization?.id ?? 'none'],
+      queryFn: () =>
+        selectedOrganization
+          ? fetchOrganizationEvents({ organizationId: selectedOrganization.id })
+          : Promise.resolve([]),
+      enabled: Boolean(selectedOrganization),
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  const activeEventFromApi = useMemo(
+    () => organizationEvents.find((event) => event.isActive) ?? null,
+    [organizationEvents],
+  );
+
+  const activeEventKey = useMemo(
+    () => activeEventFromApi?.eventKey ?? localActiveEventKey ?? null,
+    [activeEventFromApi, localActiveEventKey],
+  );
+
+  const activeEvent = useMemo(() => {
+    if (!activeEventKey) {
+      return null;
+    }
+
+    return (
+      organizationEvents.find((event) => event.eventKey === activeEventKey) ??
+      activeEventFromApi ??
+      ({ eventKey: activeEventKey, name: activeEventKey, isActive: true } as OrganizationEvent)
+    );
+  }, [activeEventFromApi, activeEventKey, organizationEvents]);
+
+  const {
+    data: pickLists = [],
+    isLoading: isLoadingPickLists,
+    isError: isPickListsError,
+    error: pickListsError,
+  } = useQuery<PickList[]>(
+    {
+      queryKey: ['picklists', selectedOrganization?.id ?? 'none', activeEventKey ?? 'all'],
+      queryFn: () =>
+        selectedOrganization
+          ? fetchPickLists({
+              organizationId: selectedOrganization.id,
+              eventKey: activeEventKey ?? undefined,
+            })
+          : Promise.resolve([]),
+      enabled: Boolean(selectedOrganization),
+      staleTime: 30 * 1000,
+    },
+  );
+
+  const {
+    data: eventTeams = [],
+    isLoading: isLoadingEventTeams,
+    isError: isEventTeamsError,
+    error: eventTeamsError,
+  } = useQuery<EventTeam[]>(
+    {
+      queryKey: ['event-teams', activeEventKey ?? 'none'],
+      queryFn: () =>
+        activeEventKey ? fetchEventTeams({ eventKey: activeEventKey }) : Promise.resolve([]),
+      enabled: Boolean(activeEventKey),
+      staleTime: 5 * 60 * 1000,
+    },
+  );
+
+  const pickListsForDisplay = useMemo(() => {
+    if (!activeEventKey) {
+      return pickLists;
+    }
+
+    return pickLists.filter((list) => !list.eventKey || list.eventKey === activeEventKey);
+  }, [activeEventKey, pickLists]);
+
+  const sortedPickLists = useMemo(() => {
+    return [...pickListsForDisplay].sort((first, second) => {
+      if (first.favorited !== second.favorited) {
+        return first.favorited ? -1 : 1;
+      }
+
+      const firstTimestamp = getTimestamp(first.updatedAt ?? first.createdAt);
+      const secondTimestamp = getTimestamp(second.updatedAt ?? second.createdAt);
+
+      return secondTimestamp - firstTimestamp;
+    });
+  }, [pickListsForDisplay]);
+
+  useEffect(() => {
+    if (sortedPickLists.length === 0) {
+      setSelectedPickListId(null);
+      return;
+    }
+
+    setSelectedPickListId((current) => {
+      if (current && sortedPickLists.some((list) => list.id === current)) {
+        return current;
+      }
+
+      return sortedPickLists[0]?.id ?? null;
+    });
+  }, [sortedPickLists]);
+
+  const selectedPickList = useMemo(
+    () => sortedPickLists.find((list) => list.id === selectedPickListId) ?? null,
+    [selectedPickListId, sortedPickLists],
+  );
+
+  const allianceRecommendations = useMemo(() => {
+    if (!selectedPickList) {
+      return [];
+    }
+
+    return buildAllianceRecommendations(selectedPickList.ranks, DEFAULT_ALLIANCE_COUNT);
+  }, [selectedPickList]);
+
+  const hasThirdPicks = useMemo(
+    () => allianceRecommendations.some((alliance) => alliance.thirdPick !== null),
+    [allianceRecommendations],
+  );
+
+  const selectedTeamNumbers = useMemo(() => {
+    const numbers = new Set<number>();
+
+    allianceRecommendations.forEach((alliance) => {
+      [alliance.captain, alliance.firstPick, alliance.secondPick, alliance.thirdPick].forEach(
+        (slot) => {
+          if (slot) {
+            numbers.add(slot.teamNumber);
+          }
+        },
+      );
+    });
+
+    return numbers;
+  }, [allianceRecommendations]);
+
+  const eventTeamsByNumber = useMemo(
+    () => new Map(eventTeams.map((team) => [team.teamNumber, team])),
+    [eventTeams],
+  );
+
+  const isLoadingAny =
+    isLoadingPickLists ||
+    isLoadingEvents ||
+    (Boolean(activeEventKey) && isLoadingEventTeams);
+
+  const pickListErrorMessage = isPickListsError
+    ? pickListsError instanceof Error
+      ? pickListsError.message
+      : 'Unable to load pick lists.'
+    : null;
+
+  const organizationEventsErrorMessage = isEventsError
+    ? organizationEventsError instanceof Error
+      ? organizationEventsError.message
+      : 'Unable to load organization events.'
+    : null;
+
+  const eventTeamsErrorMessage = isEventTeamsError
+    ? eventTeamsError instanceof Error
+      ? eventTeamsError.message
+      : 'Unable to load teams for the active event.'
+    : null;
+
+  const handleSelectPickList = useCallback((pickListId: string) => {
+    setSelectedPickListId(pickListId);
+  }, []);
+
+  const renderAllianceSlot = useCallback(
+    (label: string, rank: PickListRank | null) => {
+      if (!rank) {
+        return (
+          <View style={styles.allianceSlot}>
+            <ThemedText style={[styles.allianceSlotLabel, { color: mutedText }]}>{label}</ThemedText>
+            <ThemedText style={[styles.allianceSlotEmpty, { color: mutedText }]}>No team assigned</ThemedText>
+          </View>
+        );
+      }
+
+      const teamDetails = eventTeamsByNumber.get(rank.teamNumber);
+      const teamName = teamDetails?.teamName ?? 'Team information unavailable';
+
+      return (
+        <View style={styles.allianceSlot}>
+          <ThemedText style={[styles.allianceSlotLabel, { color: mutedText }]}>{label}</ThemedText>
+          <View style={styles.allianceSlotContent}>
+            <View style={styles.allianceRankBadge}>
+              <ThemedText style={styles.allianceRankText}>#{rank.rank}</ThemedText>
+            </View>
+            <View style={styles.allianceTeamDetails}>
+              <ThemedText type="defaultSemiBold" style={styles.allianceTeamNumber}>
+                {rank.teamNumber}
+              </ThemedText>
+              <ThemedText style={[styles.allianceTeamName, { color: mutedText }]} numberOfLines={1}>
+                {teamName}
+              </ThemedText>
+            </View>
+          </View>
+        </View>
+      );
+    },
+    [eventTeamsByNumber, mutedText],
   );
 
   return (
     <ScreenContainer>
-      <View style={styles.content}>
-        <ThemedText type="title" style={[styles.title, { color: accentColor }]}>
-          Pick Lists
-        </ThemedText>
-        <ThemedText style={[styles.subtitle, { color: subtitleColor }]}>
-          This feature is coming soon.
-        </ThemedText>
+      <Stack.Screen options={{ title: 'Pick Lists' }} />
+      <View style={styles.pageContent}>
+        <View style={styles.header}>
+          <View>
+            <ThemedText type="title" style={styles.title}>
+              Alliance Selection
+            </ThemedText>
+            <ThemedText style={[styles.subtitle, { color: mutedText }]}>View pick lists and draft planning tools.</ThemedText>
+          </View>
+          {activeEvent ? (
+            <View style={styles.eventBadge}>
+              <ThemedText style={[styles.eventBadgeText, { color: accentColor }]}>Active event</ThemedText>
+              <ThemedText type="defaultSemiBold" style={styles.eventBadgeName}>
+                {activeEvent.name ?? activeEvent.eventKey}
+              </ThemedText>
+            </View>
+          ) : null}
+        </View>
+
+        {organizationEventsErrorMessage ? (
+          <View style={[styles.banner, { borderColor: errorColor }]}>
+            <ThemedText style={[styles.bannerText, { color: errorColor }]}>{organizationEventsErrorMessage}</ThemedText>
+          </View>
+        ) : null}
+
+        {eventTeamsErrorMessage ? (
+          <View style={[styles.banner, { borderColor: errorColor }]}>
+            <ThemedText style={[styles.bannerText, { color: errorColor }]}>{eventTeamsErrorMessage}</ThemedText>
+          </View>
+        ) : null}
+
+        {pickListErrorMessage ? (
+          <View style={[styles.errorContainer, { borderColor: errorColor }]}> 
+            <ThemedText style={[styles.errorText, { color: errorColor }]}>{pickListErrorMessage}</ThemedText>
+          </View>
+        ) : null}
+
+        {!selectedOrganization ? (
+          <View style={styles.emptyState}>
+            <ThemedText type="defaultSemiBold">Join an organization to access pick lists.</ThemedText>
+            <ThemedText style={[styles.emptyStateHint, { color: mutedText }]}>Once you join, pick lists shared with your organization will appear here.</ThemedText>
+          </View>
+        ) : isLoadingAny ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator accessibilityLabel="Loading pick lists" color={accentColor} />
+            <ThemedText style={[styles.loadingText, { color: mutedText }]}>Loading pick lists…</ThemedText>
+          </View>
+        ) : sortedPickLists.length === 0 ? (
+          <View style={styles.emptyState}>
+            <ThemedText type="defaultSemiBold">No pick lists available</ThemedText>
+            <ThemedText style={[styles.emptyStateHint, { color: mutedText }]}>Create a pick list on the web dashboard to view it here.</ThemedText>
+          </View>
+        ) : (
+          <ScrollView contentContainerStyle={styles.contentWrapper}>
+            <View
+              style={[styles.card, styles.allianceCard, { backgroundColor: cardBackground, borderColor }]}
+            >
+              <View style={styles.sectionHeader}>
+                <ThemedText type="title" style={styles.sectionTitle}>
+                  Alliance overview
+                </ThemedText>
+                <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>Recommendations based on the selected pick list.</ThemedText>
+              </View>
+              {allianceRecommendations.length === 0 ? (
+                <View style={styles.emptySection}>
+                  <ThemedText style={[styles.emptySectionText, { color: mutedText }]}>Add ranked teams to your pick list to generate alliance suggestions.</ThemedText>
+                </View>
+              ) : (
+                <View style={styles.allianceList}>
+                  {allianceRecommendations.map((alliance, index) => (
+                    <View
+                      key={`alliance-${index}`}
+                      style={[styles.allianceItem, { borderColor }]}
+                    >
+                      <ThemedText type="defaultSemiBold" style={styles.allianceTitle}>
+                        Alliance {index + 1}
+                      </ThemedText>
+                      {renderAllianceSlot('Captain', alliance.captain)}
+                      {renderAllianceSlot('First pick', alliance.firstPick)}
+                      {renderAllianceSlot('Second pick', alliance.secondPick)}
+                      {hasThirdPicks ? renderAllianceSlot('Third pick', alliance.thirdPick) : null}
+                    </View>
+                  ))}
+                </View>
+              )}
+            </View>
+            <View
+              style={[styles.card, styles.pickListCard, { backgroundColor: cardBackground, borderColor }]}
+            >
+              <View style={styles.sectionHeader}>
+                <ThemedText type="title" style={styles.sectionTitle}>
+                  Pick lists
+                </ThemedText>
+                <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>Select a pick list to view the current rankings.</ThemedText>
+              </View>
+              <View style={styles.pickListChips}>
+                {sortedPickLists.map((pickList) => {
+                  const isSelected = pickList.id === selectedPickListId;
+                  return (
+                    <Pressable
+                      key={pickList.id}
+                      onPress={() => handleSelectPickList(pickList.id)}
+                      style={[
+                        styles.pickListChip,
+                        { backgroundColor: chipBackground, borderColor },
+                        isSelected ? { backgroundColor: chipSelectedBackground, borderColor: accentColor } : null,
+                      ]}
+                    >
+                      {pickList.favorited ? (
+                        <Ionicons
+                          name="star"
+                          size={14}
+                          color={accentColor}
+                          style={styles.favoriteIcon}
+                          accessibilityElementsHidden
+                        />
+                      ) : null}
+                      <ThemedText
+                        type="defaultSemiBold"
+                        style={[styles.pickListChipLabel, { color: isSelected ? accentColor : textColor }]}
+                        numberOfLines={1}
+                      >
+                        {pickList.title}
+                      </ThemedText>
+                    </Pressable>
+                  );
+                })}
+              </View>
+              {selectedPickList ? (
+                <View style={styles.previewContainer}>
+                  <PickListPreview
+                    ranks={selectedPickList.ranks}
+                    eventTeamsByNumber={eventTeamsByNumber}
+                    selectedTeamNumbers={selectedTeamNumbers}
+                  />
+                </View>
+              ) : (
+                <View style={styles.emptySection}>
+                  <ThemedText style={[styles.emptySectionText, { color: mutedText }]}>Select a pick list to view the teams it contains.</ThemedText>
+                </View>
+              )}
+            </View>
+          </ScrollView>
+        )}
       </View>
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  content: {
+  pageContent: {
     flex: 1,
+    gap: 16,
+  },
+  header: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 24,
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
     gap: 12,
   },
   title: {
-    textAlign: 'center',
+    fontSize: 28,
   },
   subtitle: {
+    marginTop: 4,
+    maxWidth: 520,
+  },
+  eventBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    backgroundColor: 'rgba(14, 165, 233, 0.12)',
+    alignItems: 'flex-start',
+    gap: 4,
+  },
+  eventBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  eventBadgeName: {
+    fontSize: 16,
+  },
+  banner: {
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  bannerText: {
     textAlign: 'center',
+  },
+  errorContainer: {
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  errorText: {
+    textAlign: 'center',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  loadingText: {
+    fontSize: 16,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 48,
+    gap: 8,
+  },
+  emptyStateHint: {
+    textAlign: 'center',
+  },
+  contentWrapper: {
+    flexGrow: 1,
+    flexDirection: 'row',
+    gap: 16,
+  },
+  card: {
+    flex: 1,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 16,
+    padding: 20,
+    gap: 20,
+    minWidth: 320,
+  },
+  allianceCard: {
+    flex: 1.1,
+  },
+  pickListCard: {
+    flex: 1,
+  },
+  sectionHeader: {
+    gap: 4,
+  },
+  sectionTitle: {
+    fontSize: 22,
+  },
+  sectionSubtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  emptySection: {
+    paddingVertical: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptySectionText: {
+    textAlign: 'center',
+  },
+  allianceList: {
+    gap: 12,
+  },
+  allianceItem: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+  },
+  allianceTitle: {
+    fontSize: 18,
+  },
+  allianceSlot: {
+    gap: 8,
+  },
+  allianceSlotLabel: {
+    fontSize: 13,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    fontWeight: '600',
+  },
+  allianceSlotEmpty: {
+    fontSize: 14,
+  },
+  allianceSlotContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  allianceRankBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(14, 165, 233, 0.12)',
+  },
+  allianceRankText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  allianceTeamDetails: {
+    flex: 1,
+    gap: 2,
+  },
+  allianceTeamNumber: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  allianceTeamName: {
+    fontSize: 14,
+  },
+  pickListChips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  pickListChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  pickListChipLabel: {
+    maxWidth: 200,
+  },
+  favoriteIcon: {
+    marginRight: 2,
+  },
+  previewContainer: {
+    flex: 1,
   },
 });

--- a/app/services/api/events.ts
+++ b/app/services/api/events.ts
@@ -1,0 +1,221 @@
+import { apiRequest, type ApiRequestParams } from './client';
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const toString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+};
+
+const toBoolean = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  return false;
+};
+
+const extractCollection = (response: unknown): unknown[] => {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  if (response && typeof response === 'object') {
+    const container = response as Record<string, unknown>;
+    const possibleKeys = ['data', 'items', 'results'];
+
+    for (const key of possibleKeys) {
+      const value = container[key];
+      if (Array.isArray(value)) {
+        return value;
+      }
+
+      if (value && typeof value === 'object') {
+        const nested = value as Record<string, unknown>;
+        for (const nestedKey of possibleKeys) {
+          const nestedValue = nested[nestedKey];
+          if (Array.isArray(nestedValue)) {
+            return nestedValue;
+          }
+        }
+      }
+    }
+  }
+
+  return [];
+};
+
+export interface OrganizationEvent {
+  eventKey: string;
+  name: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  isActive: boolean;
+}
+
+const normalizeOrganizationEvent = (value: unknown): OrganizationEvent | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const eventKey =
+    toString(record.eventKey) ||
+    toString(record.event_key) ||
+    toString(record.eventCode) ||
+    toString(record.event_code) ||
+    toString(record.key);
+
+  if (!eventKey) {
+    return null;
+  }
+
+  const name =
+    toString(record.name) ||
+    toString(record.event_name) ||
+    toString(record.title) ||
+    eventKey;
+
+  const isActive =
+    toBoolean(record.isActive) ||
+    toBoolean(record.is_active) ||
+    toBoolean(record.active);
+
+  const startDate =
+    toString(record.startDate) ||
+    toString(record.start_date) ||
+    toString(record.start);
+
+  const endDate =
+    toString(record.endDate) ||
+    toString(record.end_date) ||
+    toString(record.end);
+
+  return {
+    eventKey,
+    name: name ?? null,
+    startDate: startDate ?? null,
+    endDate: endDate ?? null,
+    isActive,
+  };
+};
+
+export interface FetchOrganizationEventsParams {
+  organizationId?: number | null;
+}
+
+export const fetchOrganizationEvents = async (
+  params?: FetchOrganizationEventsParams,
+): Promise<OrganizationEvent[]> => {
+  const requestParams: ApiRequestParams | undefined = params?.organizationId
+    ? { organization_id: params.organizationId }
+    : undefined;
+
+  const response = await apiRequest<unknown>('/organization/events', {
+    method: 'GET',
+    params: requestParams,
+  });
+
+  const items = extractCollection(response);
+
+  return items
+    .map(normalizeOrganizationEvent)
+    .filter((event): event is OrganizationEvent => event !== null)
+    .sort((a, b) => a.eventKey.localeCompare(b.eventKey));
+};
+
+export interface EventTeam {
+  teamNumber: number;
+  teamName: string | null;
+  nickname?: string | null;
+  location?: string | null;
+}
+
+const normalizeEventTeam = (value: unknown): EventTeam | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const teamNumber =
+    toNumber(record.teamNumber) ||
+    toNumber(record.team_number) ||
+    toNumber(record.team) ||
+    toNumber(record.number);
+
+  if (teamNumber === null) {
+    return null;
+  }
+
+  const teamName =
+    toString(record.teamName) ||
+    toString(record.team_name) ||
+    toString(record.nickname) ||
+    toString(record.name);
+
+  const location =
+    toString(record.location) ||
+    toString(record.city) ||
+    toString(record.state_prov);
+
+  return {
+    teamNumber,
+    teamName: teamName ?? null,
+    nickname: toString(record.nickname) ?? null,
+    location: location ?? null,
+  };
+};
+
+export interface FetchEventTeamsParams {
+  eventKey: string;
+}
+
+export const fetchEventTeams = async (
+  params: FetchEventTeamsParams,
+): Promise<EventTeam[]> => {
+  if (!params.eventKey) {
+    return [];
+  }
+
+  const requestParams: ApiRequestParams = { event_key: params.eventKey };
+
+  const response = await apiRequest<unknown>('/event/teams', {
+    method: 'GET',
+    params: requestParams,
+  });
+
+  const items = extractCollection(response);
+
+  return items
+    .map(normalizeEventTeam)
+    .filter((team): team is EventTeam => team !== null)
+    .sort((a, b) => a.teamNumber - b.teamNumber);
+};

--- a/app/services/api/index.ts
+++ b/app/services/api/index.ts
@@ -5,3 +5,5 @@ export * from './organizations';
 export * from './user';
 export * from './robot-photos';
 export * from './match-previews';
+export * from './events';
+export * from './pick-lists';

--- a/app/services/api/pick-lists.ts
+++ b/app/services/api/pick-lists.ts
@@ -1,0 +1,227 @@
+import { apiRequest, type ApiRequestParams } from './client';
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const toString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+};
+
+const toBoolean = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  return false;
+};
+
+const extractCollection = (response: unknown): unknown[] => {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  if (response && typeof response === 'object') {
+    const container = response as Record<string, unknown>;
+    const possibleKeys = ['data', 'items', 'results'];
+
+    for (const key of possibleKeys) {
+      const value = container[key];
+      if (Array.isArray(value)) {
+        return value;
+      }
+
+      if (value && typeof value === 'object') {
+        const nested = value as Record<string, unknown>;
+        for (const nestedKey of possibleKeys) {
+          const nestedValue = nested[nestedKey];
+          if (Array.isArray(nestedValue)) {
+            return nestedValue;
+          }
+        }
+      }
+    }
+  }
+
+  return [];
+};
+
+export interface PickListRank {
+  rank: number;
+  teamNumber: number;
+  notes: string;
+  dnp: boolean;
+}
+
+const normalizePickListRank = (value: unknown): PickListRank | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const rank =
+    toNumber(record.rank) ||
+    toNumber(record.rank_value) ||
+    toNumber(record.position);
+
+  const teamNumber =
+    toNumber(record.teamNumber) ||
+    toNumber(record.team_number) ||
+    toNumber(record.team);
+
+  if (rank === null || teamNumber === null) {
+    return null;
+  }
+
+  const notes = toString(record.notes) || '';
+  const dnp =
+    toBoolean(record.dnp) ||
+    toBoolean(record.is_dnp) ||
+    toBoolean(record.do_not_pick);
+
+  return {
+    rank,
+    teamNumber,
+    notes,
+    dnp,
+  };
+};
+
+export interface PickList {
+  id: string;
+  season: number | null;
+  organizationId: number | null;
+  eventKey: string | null;
+  title: string;
+  notes: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  favorited: boolean;
+  ranks: PickListRank[];
+}
+
+const normalizePickList = (value: unknown): PickList | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const id = toString(record.id) || toString(record.uuid);
+
+  if (!id) {
+    return null;
+  }
+
+  const season =
+    toNumber(record.season) ||
+    toNumber(record.season_id) ||
+    toNumber(record.year);
+
+  const organizationId =
+    toNumber(record.organizationId) ||
+    toNumber(record.organization_id) ||
+    toNumber(record.org_id);
+
+  const eventKey =
+    toString(record.eventKey) ||
+    toString(record.event_key) ||
+    toString(record.eventCode);
+
+  const title = toString(record.title) || 'Pick List';
+  const notes = toString(record.notes) || '';
+
+  const createdAt =
+    toString(record.createdAt) ||
+    toString(record.created_at) ||
+    toString(record.created) ||
+    null;
+
+  const updatedAt =
+    toString(record.updatedAt) ||
+    toString(record.updated_at) ||
+    toString(record.last_updated) ||
+    null;
+
+  const favorited =
+    toBoolean(record.favorited) ||
+    toBoolean(record.is_favorited) ||
+    toBoolean(record.favorite);
+
+  const ranksRaw = record.ranks;
+  const ranks = Array.isArray(ranksRaw)
+    ? ranksRaw
+        .map(normalizePickListRank)
+        .filter((rank): rank is PickListRank => rank !== null)
+    : [];
+
+  return {
+    id,
+    season,
+    organizationId,
+    eventKey: eventKey ?? null,
+    title,
+    notes,
+    createdAt,
+    updatedAt,
+    favorited,
+    ranks,
+  };
+};
+
+export interface FetchPickListsParams {
+  organizationId?: number | null;
+  eventKey?: string | null;
+}
+
+export const fetchPickLists = async (
+  params?: FetchPickListsParams,
+): Promise<PickList[]> => {
+  const requestParams: ApiRequestParams = {};
+
+  if (params?.organizationId != null) {
+    requestParams.organization_id = params.organizationId;
+  }
+
+  if (params?.eventKey) {
+    requestParams.event_key = params.eventKey;
+  }
+
+  const response = await apiRequest<unknown>('/picklists', {
+    method: 'GET',
+    params: Object.keys(requestParams).length > 0 ? requestParams : undefined,
+  });
+
+  const items = extractCollection(response);
+
+  return items
+    .map(normalizePickList)
+    .filter((list): list is PickList => list !== null)
+    .sort((a, b) => a.title.localeCompare(b.title));
+};

--- a/components/pick-lists/PickListPreview.tsx
+++ b/components/pick-lists/PickListPreview.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+
+import type { EventTeam } from '@/app/services/api/events';
+import type { PickListRank } from '@/app/services/api/pick-lists';
+import { ThemedText } from '@/components/themed-text';
+import { useThemeColor } from '@/hooks/use-theme-color';
+
+interface PickListPreviewProps {
+  ranks: PickListRank[];
+  eventTeamsByNumber: Map<number, EventTeam>;
+  selectedTeamNumbers: Set<number>;
+}
+
+type NormalizedPickListRanks = {
+  teams: PickListRank[];
+  dnp: PickListRank[];
+};
+
+const recalculateRanks = (ranks: PickListRank[]) => {
+  const activeRanks = ranks.filter((rank) => !rank.dnp);
+  const dnpRanks = ranks.filter((rank) => rank.dnp);
+
+  const normalizedActive = activeRanks.map((rank, index) => ({
+    ...rank,
+    rank: index + 1,
+    notes: rank.notes?.trim() ?? '',
+  }));
+
+  const normalizedDnp = dnpRanks.map((rank, index) => ({
+    ...rank,
+    rank: -(index + 1),
+    notes: rank.notes?.trim() ?? '',
+  }));
+
+  return [...normalizedActive, ...normalizedDnp];
+};
+
+const normalizeRanks = (
+  ranks: PickListRank[],
+  selectedTeamNumbers: Set<number>,
+): NormalizedPickListRanks => {
+  const sortedRanks = [...ranks].sort((first, second) => {
+    if (first.dnp === second.dnp) {
+      if (first.dnp) {
+        return Math.abs(first.rank) - Math.abs(second.rank);
+      }
+
+      return first.rank - second.rank;
+    }
+
+    return first.dnp ? 1 : -1;
+  });
+
+  const recalculated = recalculateRanks(sortedRanks);
+
+  const filtered = recalculated.filter((rank) => !selectedTeamNumbers.has(rank.teamNumber));
+
+  return {
+    teams: filtered.filter((rank) => !rank.dnp),
+    dnp: filtered.filter((rank) => rank.dnp),
+  };
+};
+
+const PickListEmptyState = ({ label }: { label: string }) => (
+  <View style={styles.emptyState}>
+    <ThemedText style={styles.emptyStateText}>{label}</ThemedText>
+  </View>
+);
+
+const PickListItem = ({
+  rank,
+  team,
+  isDnp,
+  isSelected,
+  mutedText,
+  borderColor,
+  selectedBackground,
+  highlightColor,
+}: {
+  rank: PickListRank;
+  team: EventTeam | undefined;
+  isDnp: boolean;
+  isSelected: boolean;
+  mutedText: string;
+  borderColor: string;
+  selectedBackground: string;
+  highlightColor: string;
+}) => {
+  return (
+    <View
+      style={[
+        styles.item,
+        { borderColor },
+        isSelected ? { backgroundColor: selectedBackground, borderColor: highlightColor } : null,
+      ]}
+    >
+      <View style={styles.itemHeader}>
+        <View style={styles.itemRankBadge}>
+          <ThemedText style={styles.itemRankText}>
+            {isDnp ? 'DNP' : `#${rank.rank}`}
+          </ThemedText>
+        </View>
+        <ThemedText type="defaultSemiBold" style={styles.itemTeamNumber}>
+          {rank.teamNumber}
+        </ThemedText>
+      </View>
+      <ThemedText style={[styles.itemTeamName, { color: mutedText }]} numberOfLines={1}>
+        {team?.teamName ?? 'Team information unavailable'}
+      </ThemedText>
+      {rank.notes ? (
+        <ThemedText style={[styles.itemNotes, { color: mutedText }]} numberOfLines={2}>
+          {rank.notes}
+        </ThemedText>
+      ) : null}
+    </View>
+  );
+};
+
+export function PickListPreview({
+  ranks,
+  eventTeamsByNumber,
+  selectedTeamNumbers,
+}: PickListPreviewProps) {
+  const { teams, dnp } = useMemo(
+    () => normalizeRanks(ranks, selectedTeamNumbers),
+    [ranks, selectedTeamNumbers],
+  );
+
+  const hasDnp = dnp.length > 0;
+
+  const [activeTab, setActiveTab] = useState<'teams' | 'dnp'>(teams.length > 0 ? 'teams' : 'dnp');
+
+  useEffect(() => {
+    if (!hasDnp && activeTab === 'dnp') {
+      setActiveTab('teams');
+      return;
+    }
+
+    if (hasDnp && activeTab === 'teams' && teams.length === 0) {
+      setActiveTab('dnp');
+    }
+  }, [activeTab, hasDnp, teams.length]);
+
+  const borderColor = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.08)', dark: 'rgba(148, 163, 184, 0.25)' },
+    'text',
+  );
+  const mutedText = useThemeColor({ light: '#475569', dark: '#94A3B8' }, 'text');
+  const selectedBackground = useThemeColor(
+    { light: 'rgba(14, 165, 233, 0.12)', dark: 'rgba(125, 211, 252, 0.16)' },
+    'tint',
+  );
+  const highlightColor = useThemeColor({ light: '#0ea5e9', dark: '#38bdf8' }, 'tint');
+  const tabActiveColor = useThemeColor({ light: '#0a7ea4', dark: '#7cd4f7' }, 'tint');
+  const tabInactiveColor = useThemeColor(
+    { light: 'rgba(15, 23, 42, 0.6)', dark: 'rgba(226, 232, 240, 0.65)' },
+    'text',
+  );
+
+  const renderList = (items: PickListRank[], isDnp: boolean) => {
+    if (items.length === 0) {
+      return (
+        <PickListEmptyState
+          label={isDnp ? 'No teams marked as DNP.' : 'No teams available in this pick list.'}
+        />
+      );
+    }
+
+    return items.map((item) => (
+      <PickListItem
+        key={`${isDnp ? 'dnp' : 'team'}-${item.teamNumber}-${Math.abs(item.rank)}`}
+        rank={item}
+        team={eventTeamsByNumber.get(item.teamNumber)}
+        isDnp={isDnp}
+        isSelected={selectedTeamNumbers.has(item.teamNumber)}
+        mutedText={mutedText}
+        borderColor={borderColor}
+        selectedBackground={selectedBackground}
+        highlightColor={highlightColor}
+      />
+    ));
+  };
+
+  if (!hasDnp) {
+    return (
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.listContainer}>
+        {renderList(teams, false)}
+      </ScrollView>
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      <View style={[styles.tabBar, { borderColor }]}> 
+        <Pressable
+          onPress={() => setActiveTab('teams')}
+          style={[styles.tabItem, activeTab === 'teams' ? styles.activeTab : null]}
+        >
+          <ThemedText
+            type="defaultSemiBold"
+            style={{ color: activeTab === 'teams' ? tabActiveColor : tabInactiveColor }}
+          >
+            Teams
+          </ThemedText>
+        </Pressable>
+        <Pressable
+          onPress={() => setActiveTab('dnp')}
+          style={[styles.tabItem, activeTab === 'dnp' ? styles.activeTab : null]}
+        >
+          <ThemedText
+            type="defaultSemiBold"
+            style={{ color: activeTab === 'dnp' ? tabActiveColor : tabInactiveColor }}
+          >
+            DNP
+          </ThemedText>
+        </Pressable>
+      </View>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.listContainer}>
+        {renderList(activeTab === 'teams' ? teams : dnp, activeTab === 'dnp')}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  scroll: {
+    flex: 1,
+  },
+  listContainer: {
+    paddingVertical: 8,
+    gap: 12,
+  },
+  emptyState: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyStateText: {
+    textAlign: 'center',
+  },
+  item: {
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    gap: 6,
+  },
+  itemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  itemRankBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: 'rgba(14, 165, 233, 0.12)',
+  },
+  itemRankText: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  itemTeamNumber: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  itemTeamName: {
+    fontSize: 14,
+  },
+  itemNotes: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  tabBar: {
+    flexDirection: 'row',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  tabItem: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 10,
+  },
+  activeTab: {
+    borderBottomWidth: 2,
+  },
+});

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -124,6 +124,30 @@ function initializeExpoSqliteDb() {
       role TEXT,
       FOREIGN KEY (organization_id) REFERENCES organization(id)
     );`,
+    `CREATE TABLE IF NOT EXISTS picklist (
+      id TEXT PRIMARY KEY NOT NULL,
+      season INTEGER NOT NULL,
+      organization_id INTEGER NOT NULL,
+      event_key TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT 'Pick List',
+      notes TEXT NOT NULL DEFAULT '',
+      created INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+      last_updated INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+      favorited INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (season) REFERENCES season(id),
+      FOREIGN KEY (organization_id) REFERENCES organization(id),
+      FOREIGN KEY (event_key) REFERENCES frcevent(event_key)
+    );`,
+    `CREATE TABLE IF NOT EXISTS picklist_rank (
+      picklist_id TEXT NOT NULL,
+      rank INTEGER NOT NULL,
+      team_number INTEGER NOT NULL,
+      notes TEXT NOT NULL DEFAULT '',
+      dnp INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (picklist_id, rank),
+      FOREIGN KEY (picklist_id) REFERENCES picklist(id),
+      FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
+    );`,
     `CREATE TABLE IF NOT EXISTS robot_photos (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       event_key TEXT NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -166,6 +166,68 @@ export const userOrganizations = sqliteTable(
 export type UserOrganization = InferSelectModel<typeof userOrganizations>;
 export type NewUserOrganization = InferInsertModel<typeof userOrganizations>;
 
+export const pickLists = sqliteTable(
+  'picklist',
+  {
+    id: text('id').primaryKey(),
+    season: integer('season').notNull(),
+    organizationId: integer('organization_id').notNull(),
+    eventKey: text('event_key').notNull(),
+    title: text('title').notNull().default('Pick List'),
+    notes: text('notes').notNull().default(''),
+    created: integer('created').notNull().default(sql`(strftime('%s','now'))`),
+    lastUpdated: integer('last_updated').notNull().default(sql`(strftime('%s','now'))`),
+    favorited: integer('favorited').notNull().default(0),
+  },
+  (table) => ({
+    seasonRef: foreignKey({
+      columns: [table.season],
+      foreignColumns: [seasons.id],
+      name: 'picklist_season_fk',
+    }),
+    organizationRef: foreignKey({
+      columns: [table.organizationId],
+      foreignColumns: [organizations.id],
+      name: 'picklist_organization_fk',
+    }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'picklist_event_fk',
+    }),
+  }),
+);
+
+export type PickList = InferSelectModel<typeof pickLists>;
+export type NewPickList = InferInsertModel<typeof pickLists>;
+
+export const pickListRanks = sqliteTable(
+  'picklist_rank',
+  {
+    pickListId: text('picklist_id').notNull(),
+    rank: integer('rank').notNull(),
+    teamNumber: integer('team_number').notNull(),
+    notes: text('notes').notNull().default(''),
+    dnp: integer('dnp').notNull().default(0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.pickListId, table.rank] }),
+    pickListRef: foreignKey({
+      columns: [table.pickListId],
+      foreignColumns: [pickLists.id],
+      name: 'picklist_rank_picklist_fk',
+    }),
+    teamRef: foreignKey({
+      columns: [table.teamNumber],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'picklist_rank_team_fk',
+    }),
+  }),
+);
+
+export type PickListRank = InferSelectModel<typeof pickListRanks>;
+export type NewPickListRank = InferInsertModel<typeof pickListRanks>;
+
 export const robotPhotos = sqliteTable(
   'robot_photos',
   {


### PR DESCRIPTION
## Summary
- make the pick lists drawer entry tablet-only and guard the route
- add local schema and API helpers for pick list and rank data
- build a tablet alliance selection view that reads pick lists and previews rankings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6905189be69483269f630364e7a462a9