### PR TITLE
Load pick lists from synced database

### DIFF
--- a/app/services/api/pick-lists.ts
+++ b/app/services/api/pick-lists.ts
@@ -1,3 +1,5 @@
+import type { PickList, PickListRank } from '@/app/services/pick-lists/types';
+
 import { apiRequest, type ApiRequestParams } from './client';
 
 const toNumber = (value: unknown): number | null => {
@@ -73,13 +75,6 @@ const extractCollection = (response: unknown): unknown[] => {
   return [];
 };
 
-export interface PickListRank {
-  rank: number;
-  teamNumber: number;
-  notes: string;
-  dnp: boolean;
-}
-
 const normalizePickListRank = (value: unknown): PickListRank | null => {
   if (!value || typeof value !== 'object') {
     return null;
@@ -113,19 +108,6 @@ const normalizePickListRank = (value: unknown): PickListRank | null => {
     dnp,
   };
 };
-
-export interface PickList {
-  id: string;
-  season: number | null;
-  organizationId: number | null;
-  eventKey: string | null;
-  title: string;
-  notes: string;
-  createdAt: string | null;
-  updatedAt: string | null;
-  favorited: boolean;
-  ranks: PickListRank[];
-}
 
 const normalizePickList = (value: unknown): PickList | null => {
   if (!value || typeof value !== 'object') {

--- a/app/services/pick-lists/index.ts
+++ b/app/services/pick-lists/index.ts
@@ -1,0 +1,3 @@
+export type { PickList, PickListRank } from './types';
+export { getPickListsFromDatabase, type GetPickListsOptions } from './storage';
+export { syncPickLists, type SyncPickListsResult } from './sync';

--- a/app/services/pick-lists/storage.ts
+++ b/app/services/pick-lists/storage.ts
@@ -1,0 +1,121 @@
+import { getDbOrThrow, schema } from '@/db';
+import { and, asc, eq, inArray, isNull } from 'drizzle-orm';
+
+import type { PickList, PickListRank } from './types';
+
+export type GetPickListsOptions = {
+  organizationId?: number | null;
+  eventKey?: string | null;
+};
+
+const toTimestampString = (value: number | null | undefined): string | null => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return new Date(value * 1000).toISOString();
+};
+
+const toBoolean = (value: number | boolean | null | undefined): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return value === 1;
+};
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeRank = (row: typeof schema.pickListRanks.$inferSelect): PickListRank => ({
+  rank: row.rank,
+  teamNumber: row.teamNumber,
+  notes: typeof row.notes === 'string' ? row.notes : '',
+  dnp: toBoolean(row.dnp),
+});
+
+export async function getPickListsFromDatabase(
+  options: GetPickListsOptions = {},
+): Promise<PickList[]> {
+  const db = getDbOrThrow();
+
+  const conditions = [] as ReturnType<typeof eq>[];
+
+  if (options.organizationId != null) {
+    conditions.push(eq(schema.pickLists.organizationId, options.organizationId));
+  }
+
+  if (options.eventKey !== undefined) {
+    const eventCondition =
+      options.eventKey === null
+        ? isNull(schema.pickLists.eventKey)
+        : eq(schema.pickLists.eventKey, options.eventKey);
+
+    conditions.push(eventCondition);
+  }
+
+  let query = db.select().from(schema.pickLists);
+
+  if (conditions.length === 1) {
+    query = query.where(conditions[0]);
+  } else if (conditions.length > 1) {
+    query = query.where(and(...conditions));
+  }
+
+  const pickListRows = query.all();
+
+  const pickListIds = pickListRows
+    .map((row) => row.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const rankRows =
+    pickListIds.length > 0
+      ? db
+          .select()
+          .from(schema.pickListRanks)
+          .where(inArray(schema.pickListRanks.pickListId, pickListIds))
+          .orderBy(asc(schema.pickListRanks.rank))
+          .all()
+      : [];
+
+  const ranksByPickList = new Map<string, PickListRank[]>();
+
+  rankRows.forEach((row) => {
+    const pickListId = normalizeText(row.pickListId);
+
+    if (!pickListId) {
+      return;
+    }
+
+    const ranks = ranksByPickList.get(pickListId) ?? [];
+    ranks.push(normalizeRank(row));
+    ranksByPickList.set(pickListId, ranks);
+  });
+
+  return pickListRows.map((row): PickList => {
+    const id = typeof row.id === 'string' ? row.id : String(row.id);
+    const rawEventKey = normalizeText(row.eventKey);
+
+    return {
+      id,
+      season: typeof row.season === 'number' ? row.season : null,
+      organizationId:
+        typeof row.organizationId === 'number' && Number.isFinite(row.organizationId)
+          ? row.organizationId
+          : null,
+      eventKey: rawEventKey,
+      title: typeof row.title === 'string' && row.title.trim().length > 0 ? row.title : 'Pick List',
+      notes: typeof row.notes === 'string' ? row.notes : '',
+      createdAt: toTimestampString(row.created),
+      updatedAt: toTimestampString(row.lastUpdated),
+      favorited: toBoolean(row.favorited),
+      ranks: ranksByPickList.get(id) ?? [],
+    };
+  });
+}

--- a/app/services/pick-lists/sync.ts
+++ b/app/services/pick-lists/sync.ts
@@ -1,0 +1,143 @@
+import { fetchPickLists } from '@/app/services/api/pick-lists';
+import { getDbOrThrow, schema } from '@/db';
+import { eq, inArray } from 'drizzle-orm';
+
+export type SyncPickListsResult = {
+  received: number;
+  created: number;
+  updated: number;
+  removed: number;
+  ranksInserted: number;
+};
+
+const toUnixSeconds = (value: string | null | undefined): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+};
+
+const normalizeEventKey = (value: string | null): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export async function syncPickLists(organizationId: number): Promise<SyncPickListsResult> {
+  const remotePickLists = await fetchPickLists({ organizationId });
+  const db = getDbOrThrow();
+
+  let created = 0;
+  let updated = 0;
+  let removed = 0;
+  let ranksInserted = 0;
+
+  db.transaction((tx) => {
+    const existingRows = tx
+      .select({ id: schema.pickLists.id })
+      .from(schema.pickLists)
+      .where(eq(schema.pickLists.organizationId, organizationId))
+      .all();
+
+    const existingIds = new Set(
+      existingRows
+        .map((row) => (typeof row.id === 'string' ? row.id : null))
+        .filter((id): id is string => id !== null),
+    );
+
+    const remoteIds = new Set(remotePickLists.map((list) => list.id));
+    const idsToRemove = [...existingIds].filter((id) => !remoteIds.has(id));
+
+    if (idsToRemove.length > 0) {
+      tx
+        .delete(schema.pickListRanks)
+        .where(inArray(schema.pickListRanks.pickListId, idsToRemove))
+        .run();
+      tx.delete(schema.pickLists).where(inArray(schema.pickLists.id, idsToRemove)).run();
+      removed = idsToRemove.length;
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    for (const list of remotePickLists) {
+      const createdSeconds = toUnixSeconds(list.createdAt) ?? nowSeconds;
+      const updatedSeconds = toUnixSeconds(list.updatedAt) ?? createdSeconds;
+      const season =
+        typeof list.season === 'number' && Number.isFinite(list.season) ? list.season : null;
+      const organizationValue =
+        typeof list.organizationId === 'number' && Number.isFinite(list.organizationId)
+          ? list.organizationId
+          : organizationId;
+      const eventKey = normalizeEventKey(list.eventKey);
+
+      tx
+        .insert(schema.pickLists)
+        .values({
+          id: list.id,
+          season,
+          organizationId: organizationValue,
+          eventKey,
+          title: list.title,
+          notes: list.notes,
+          created: createdSeconds,
+          lastUpdated: updatedSeconds,
+          favorited: list.favorited ? 1 : 0,
+        })
+        .onConflictDoUpdate({
+          target: schema.pickLists.id,
+          set: {
+            season,
+            organizationId: organizationValue,
+            eventKey,
+            title: list.title,
+            notes: list.notes,
+            lastUpdated: updatedSeconds,
+            favorited: list.favorited ? 1 : 0,
+          },
+        })
+        .run();
+
+      if (existingIds.has(list.id)) {
+        updated += 1;
+      } else {
+        created += 1;
+      }
+
+      tx.delete(schema.pickListRanks).where(eq(schema.pickListRanks.pickListId, list.id)).run();
+
+      if (list.ranks.length > 0) {
+        const rankValues = [...list.ranks]
+          .sort((first, second) => first.rank - second.rank)
+          .map((rank) => ({
+            pickListId: list.id,
+            rank: rank.rank,
+            teamNumber: rank.teamNumber,
+            notes: rank.notes,
+            dnp: rank.dnp ? 1 : 0,
+          }));
+
+        tx.insert(schema.pickListRanks).values(rankValues).run();
+        ranksInserted += rankValues.length;
+      }
+    }
+  });
+
+  return {
+    received: remotePickLists.length,
+    created,
+    updated,
+    removed,
+    ranksInserted,
+  };
+}

--- a/app/services/pick-lists/types.ts
+++ b/app/services/pick-lists/types.ts
@@ -1,0 +1,19 @@
+export type PickListRank = {
+  rank: number;
+  teamNumber: number;
+  notes: string;
+  dnp: boolean;
+};
+
+export type PickList = {
+  id: string;
+  season: number | null;
+  organizationId: number | null;
+  eventKey: string | null;
+  title: string;
+  notes: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  favorited: boolean;
+  ranks: PickListRank[];
+};

--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -1,6 +1,7 @@
 import { getUserEvent } from './api/user';
 import { apiRequest } from './api/client';
 import { retrieveEventInfo, type RetrieveEventInfoResult } from './event-info';
+import { syncPickLists, type SyncPickListsResult } from './pick-lists';
 import { getActiveEvent, setActiveEvent } from './logged-in-event';
 import { syncAlreadyScoutedEntries } from './already-scouted';
 import { syncAlreadyPitScoutedEntries } from './pit-scouting';
@@ -21,6 +22,7 @@ export type SyncDataWithServerResult = {
   alreadySuperScoutedUpdated: number;
   robotPhotosUploaded: number;
   superScoutFieldsSynced: number;
+  pickLists: SyncPickListsResult;
 };
 
 const normalizeEventCode = (rawEventCode: unknown): string | null => {
@@ -126,6 +128,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
   }
 
   const eventInfo = await retrieveEventInfo();
+  const pickLists = await syncPickLists(organizationId);
   const db = getDbOrThrow();
 
   const superScoutFieldsSynced = await syncSuperScoutFields();
@@ -292,5 +295,6 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
     alreadySuperScoutedUpdated,
     robotPhotosUploaded,
     superScoutFieldsSynced,
+    pickLists,
   };
 }

--- a/components/pick-lists/PickListPreview.tsx
+++ b/components/pick-lists/PickListPreview.tsx
@@ -2,14 +2,14 @@ import { useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import type { EventTeam } from '@/app/services/api/events';
-import type { PickListRank } from '@/app/services/api/pick-lists';
+import type { PickListRank } from '@/app/services/pick-lists';
 import { ThemedText } from '@/components/themed-text';
 import { useThemeColor } from '@/hooks/use-theme-color';
 
 interface PickListPreviewProps {
   ranks: PickListRank[];
   eventTeamsByNumber: Map<number, EventTeam>;
-  selectedTeamNumbers: Set<number>;
+  selectedTeamNumbers?: Set<number>;
 }
 
 type NormalizedPickListRanks = {
@@ -117,10 +117,12 @@ const PickListItem = ({
   );
 };
 
+const EMPTY_SELECTED_TEAMS = new Set<number>();
+
 export function PickListPreview({
   ranks,
   eventTeamsByNumber,
-  selectedTeamNumbers,
+  selectedTeamNumbers = EMPTY_SELECTED_TEAMS,
 }: PickListPreviewProps) {
   const { teams, dnp } = useMemo(
     () => normalizeRanks(ranks, selectedTeamNumbers),

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -126,9 +126,9 @@ function initializeExpoSqliteDb() {
     );`,
     `CREATE TABLE IF NOT EXISTS picklist (
       id TEXT PRIMARY KEY NOT NULL,
-      season INTEGER NOT NULL,
+      season INTEGER,
       organization_id INTEGER NOT NULL,
-      event_key TEXT NOT NULL,
+      event_key TEXT,
       title TEXT NOT NULL DEFAULT 'Pick List',
       notes TEXT NOT NULL DEFAULT '',
       created INTEGER NOT NULL DEFAULT (strftime('%s','now')),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -170,9 +170,9 @@ export const pickLists = sqliteTable(
   'picklist',
   {
     id: text('id').primaryKey(),
-    season: integer('season').notNull(),
+    season: integer('season'),
     organizationId: integer('organization_id').notNull(),
-    eventKey: text('event_key').notNull(),
+    eventKey: text('event_key'),
     title: text('title').notNull().default('Pick List'),
     notes: text('notes').notNull().default(''),
     created: integer('created').notNull().default(sql`(strftime('%s','now'))`),


### PR DESCRIPTION
## Summary
- store pick lists and ranks locally during the sync workflow and expose helpers for querying them
- update the pick lists screen to use locally synced data, simplify the UI, and remove alliance recommendations
- invalidate cached pick list queries after sync and adjust pick list preview to the new data types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69051f382584832699fbef2562e8dc84