### PR TITLE
Remove season foreign key constraint from picklist table

### DIFF
--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -134,7 +134,6 @@ function initializeExpoSqliteDb() {
       created INTEGER NOT NULL DEFAULT (strftime('%s','now')),
       last_updated INTEGER NOT NULL DEFAULT (strftime('%s','now')),
       favorited INTEGER NOT NULL DEFAULT 0,
-      FOREIGN KEY (season) REFERENCES season(id),
       FOREIGN KEY (organization_id) REFERENCES organization(id),
       FOREIGN KEY (event_key) REFERENCES frcevent(event_key)
     );`,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -180,11 +180,6 @@ export const pickLists = sqliteTable(
     favorited: integer('favorited').notNull().default(0),
   },
   (table) => ({
-    seasonRef: foreignKey({
-      columns: [table.season],
-      foreignColumns: [seasons.id],
-      name: 'picklist_season_fk',
-    }),
     organizationRef: foreignKey({
       columns: [table.organizationId],
       foreignColumns: [organizations.id],


### PR DESCRIPTION
## Summary
- remove the picklist season foreign key constraint from the SQLite initialization script
- drop the season foreign key definition from the drizzle schema so inserts no longer require a season record

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905241352d48326a9b55b26faf38028