### PR TITLE
Add alliance selection card to pick list view

### DIFF
--- a/app/screens/PickLists/PickListsScreen.tsx
+++ b/app/screens/PickLists/PickListsScreen.tsx
@@ -255,72 +255,95 @@ export function PickListsScreen() {
           </View>
         ) : (
           <ScrollView contentContainerStyle={styles.contentWrapper}>
-            <View
-              style={[styles.card, styles.pickListCard, { backgroundColor: cardBackground, borderColor }]}
-            >
-              <View style={styles.sectionHeader}>
-                <ThemedText type="title" style={styles.sectionTitle}>
-                  Pick List
-                </ThemedText>
-                <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>Select a pick list to view the current rankings.</ThemedText>
-              </View>
-              <View style={styles.dropdownContainer}>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityState={{ expanded: isPickListDropdownOpen }}
-                  onPress={() => setIsPickListDropdownOpen((current) => !current)}
-                  style={[styles.dropdownTrigger, { borderColor, backgroundColor: chipBackground }]}
-                >
-                  <ThemedText
-                    type="defaultSemiBold"
-                    style={[styles.dropdownLabel, { color: textColor }]}
-                    numberOfLines={1}
-                  >
-                    {selectedPickList?.title ?? 'Select a pick list'}
+            <View style={styles.cardRow}>
+              <View
+                style={[styles.card, styles.allianceCard, { backgroundColor: cardBackground, borderColor }]}
+              >
+                <View style={styles.sectionHeader}>
+                  <ThemedText type="title" style={styles.sectionTitle}>
+                    Alliance Selection
                   </ThemedText>
-                  <ThemedText style={[styles.dropdownIcon, { color: mutedText }]}> 
-                    {isPickListDropdownOpen ? '▲' : '▼'}
+                  <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>
+                    Keep track of alliance picks as they happen.
                   </ThemedText>
-                </Pressable>
-                {isPickListDropdownOpen ? (
-                  <View style={[styles.dropdownList, { borderColor, backgroundColor: cardBackground }]}>
-                    <ScrollView nestedScrollEnabled style={styles.dropdownScroll}>
-                      {sortedPickLists.map((pickList) => {
-                        const isSelected = pickList.id === selectedPickListId;
-                        return (
-                          <Pressable
-                            key={pickList.id}
-                            onPress={() => handleSelectPickList(pickList.id)}
-                            style={[
-                              styles.dropdownOption,
-                              isSelected ? { backgroundColor: chipBackground } : null,
-                            ]}
-                          >
-                            <ThemedText
-                              style={[styles.dropdownOptionLabel, { color: textColor }]}
-                              numberOfLines={1}
-                            >
-                              {pickList.title}
-                            </ThemedText>
-                          </Pressable>
-                        );
-                      })}
-                    </ScrollView>
-                  </View>
-                ) : null}
-              </View>
-              {selectedPickList ? (
-                <View style={styles.previewContainer}>
-                  <PickListPreview
-                    ranks={selectedPickList.ranks}
-                    eventTeamsByNumber={eventTeamsByNumber}
-                  />
                 </View>
-              ) : (
                 <View style={styles.emptySection}>
-                  <ThemedText style={[styles.emptySectionText, { color: mutedText }]}>Select a pick list to view the teams it contains.</ThemedText>
+                  <ThemedText style={[styles.emptySectionText, { color: mutedText }]}>
+                    Select teams to build your alliance.
+                  </ThemedText>
                 </View>
-              )}
+              </View>
+              <View
+                style={[styles.card, styles.pickListCard, { backgroundColor: cardBackground, borderColor }]}
+              >
+                <View style={styles.sectionHeader}>
+                  <ThemedText type="title" style={styles.sectionTitle}>
+                    Pick List
+                  </ThemedText>
+                  <ThemedText style={[styles.sectionSubtitle, { color: mutedText }]}>
+                    Select a pick list to view the current rankings.
+                  </ThemedText>
+                </View>
+                <View style={styles.dropdownContainer}>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded: isPickListDropdownOpen }}
+                    onPress={() => setIsPickListDropdownOpen((current) => !current)}
+                    style={[styles.dropdownTrigger, { borderColor, backgroundColor: chipBackground }]}
+                  >
+                    <ThemedText
+                      type="defaultSemiBold"
+                      style={[styles.dropdownLabel, { color: textColor }]}
+                      numberOfLines={1}
+                    >
+                      {selectedPickList?.title ?? 'Select a pick list'}
+                    </ThemedText>
+                    <ThemedText style={[styles.dropdownIcon, { color: mutedText }]}>
+                      {isPickListDropdownOpen ? '▲' : '▼'}
+                    </ThemedText>
+                  </Pressable>
+                  {isPickListDropdownOpen ? (
+                    <View style={[styles.dropdownList, { borderColor, backgroundColor: cardBackground }]}>
+                      <ScrollView nestedScrollEnabled style={styles.dropdownScroll}>
+                        {sortedPickLists.map((pickList) => {
+                          const isSelected = pickList.id === selectedPickListId;
+                          return (
+                            <Pressable
+                              key={pickList.id}
+                              onPress={() => handleSelectPickList(pickList.id)}
+                              style={[
+                                styles.dropdownOption,
+                                isSelected ? { backgroundColor: chipBackground } : null,
+                              ]}
+                            >
+                              <ThemedText
+                                style={[styles.dropdownOptionLabel, { color: textColor }]}
+                                numberOfLines={1}
+                              >
+                                {pickList.title}
+                              </ThemedText>
+                            </Pressable>
+                          );
+                        })}
+                      </ScrollView>
+                    </View>
+                  ) : null}
+                </View>
+                {selectedPickList ? (
+                  <View style={styles.previewContainer}>
+                    <PickListPreview
+                      ranks={selectedPickList.ranks}
+                      eventTeamsByNumber={eventTeamsByNumber}
+                    />
+                  </View>
+                ) : (
+                  <View style={styles.emptySection}>
+                    <ThemedText style={[styles.emptySectionText, { color: mutedText }]}>
+                      Select a pick list to view the teams it contains.
+                    </ThemedText>
+                  </View>
+                )}
+              </View>
             </View>
           </ScrollView>
         )}
@@ -403,6 +426,11 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     gap: 16,
   },
+  cardRow: {
+    flexDirection: 'row',
+    gap: 16,
+    flexWrap: 'wrap',
+  },
   card: {
     flex: 1,
     borderWidth: StyleSheet.hairlineWidth,
@@ -410,6 +438,9 @@ const styles = StyleSheet.create({
     padding: 20,
     gap: 20,
     minWidth: 320,
+  },
+  allianceCard: {
+    flex: 1,
   },
   pickListCard: {
     flex: 1,

--- a/components/pick-lists/PickListPreview.tsx
+++ b/components/pick-lists/PickListPreview.tsx
@@ -101,13 +101,15 @@ const PickListItem = ({
             {isDnp ? 'DNP' : `#${rank.rank}`}
           </ThemedText>
         </View>
-        <ThemedText type="defaultSemiBold" style={styles.itemTeamNumber}>
-          {rank.teamNumber}
-        </ThemedText>
+        <View style={styles.itemTeamInfo}>
+          <ThemedText type="defaultSemiBold" style={styles.itemTeamNumber} numberOfLines={1}>
+            {rank.teamNumber}
+          </ThemedText>
+          <ThemedText style={[styles.itemTeamName, { color: mutedText }]} numberOfLines={1}>
+            {team?.teamName ?? 'Team information unavailable'}
+          </ThemedText>
+        </View>
       </View>
-      <ThemedText style={[styles.itemTeamName, { color: mutedText }]} numberOfLines={1}>
-        {team?.teamName ?? 'Team information unavailable'}
-      </ThemedText>
       {rank.notes ? (
         <ThemedText style={[styles.itemNotes, { color: mutedText }]} numberOfLines={2}>
           {rank.notes}
@@ -255,7 +257,6 @@ const styles = StyleSheet.create({
   itemHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
     gap: 12,
   },
   itemRankBadge: {
@@ -270,12 +271,19 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.6,
   },
+  itemTeamInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
   itemTeamNumber: {
     fontSize: 18,
     fontWeight: '700',
   },
   itemTeamName: {
     fontSize: 14,
+    flexShrink: 1,
   },
   itemNotes: {
     fontSize: 13,


### PR DESCRIPTION
## Summary
- show pick list team names alongside their rank to make the list easier to scan
- introduce an Alliance Selection card beside the pick list for future tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905257310388326b1aabacf0507fafb