### PR TITLE
Add prescout match progress indicators on team cards

### DIFF
--- a/app/screens/Prescout/PrescoutScreen.tsx
+++ b/app/screens/Prescout/PrescoutScreen.tsx
@@ -27,5 +27,11 @@ export function PrescoutScreen() {
     });
   };
 
-  return <TeamListScreen title="Prescout" onTeamPress={handleTeamPress} />;
+  return (
+    <TeamListScreen
+      title="Prescout"
+      onTeamPress={handleTeamPress}
+      showPrescoutProgress
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add an optional prescout progress indicator to the shared team list screen
- highlight prescout team cards when 10 or more matches have been recorded
- surface prescout match counts on the prescout landing screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a5a8b8bc88326a7fdada76315dc37