### PR TITLE
Sync prescout data with upload tracking

### DIFF
--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -58,6 +58,120 @@ const normalizeSuperScoutField = (
   return { key: normalizedKey, label: normalizedLabel };
 };
 
+type RemotePrescoutResponse = {
+  event_key?: unknown;
+  team_number?: unknown;
+  match_number?: unknown;
+  match_level?: unknown;
+  notes?: unknown;
+  al4c?: unknown;
+  al3c?: unknown;
+  al2c?: unknown;
+  al1c?: unknown;
+  tl4c?: unknown;
+  tl3c?: unknown;
+  tl2c?: unknown;
+  tl1c?: unknown;
+  aProcessor?: unknown;
+  tProcessor?: unknown;
+  aNet?: unknown;
+  tNet?: unknown;
+  a_processor?: unknown;
+  t_processor?: unknown;
+  a_net?: unknown;
+  t_net?: unknown;
+  endgame?: unknown;
+  organization_id?: unknown;
+};
+
+const parseNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const normalizeCountValue = (value: unknown): number => {
+  const parsed = parseNumericValue(value);
+
+  if (parsed === null) {
+    return 0;
+  }
+
+  const rounded = Math.trunc(parsed);
+  return rounded >= 0 ? rounded : 0;
+};
+
+const normalizeEndgameValue = (value: unknown): 'NONE' | 'PARK' | 'SHALLOW' | 'DEEP' => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toUpperCase();
+
+    if (normalized === 'PARK' || normalized === 'SHALLOW' || normalized === 'DEEP') {
+      return normalized;
+    }
+  }
+
+  return 'NONE';
+};
+
+type NormalizedPrescoutEntry = {
+  organizationId: number | null;
+  row: typeof schema.prescoutMatchData2025.$inferInsert;
+};
+
+const normalizePrescoutResponse = (
+  item: RemotePrescoutResponse,
+): NormalizedPrescoutEntry | null => {
+  const eventKey = typeof item.event_key === 'string' ? item.event_key.trim() : '';
+  const rawMatchLevel = typeof item.match_level === 'string' ? item.match_level.trim() : '';
+  const matchLevel = rawMatchLevel.toUpperCase();
+  const teamNumber = parseNumericValue(item.team_number);
+  const matchNumber = parseNumericValue(item.match_number);
+  const organizationId = parseNumericValue(item.organization_id);
+
+  if (!eventKey || !matchLevel || teamNumber === null || matchNumber === null) {
+    return null;
+  }
+
+  const notes = typeof item.notes === 'string' ? item.notes : null;
+
+  const row: typeof schema.prescoutMatchData2025.$inferInsert = {
+    eventKey,
+    teamNumber: Math.trunc(teamNumber),
+    matchNumber: Math.trunc(matchNumber),
+    matchLevel,
+    notes,
+    al4c: normalizeCountValue(item.al4c),
+    al3c: normalizeCountValue(item.al3c),
+    al2c: normalizeCountValue(item.al2c),
+    al1c: normalizeCountValue(item.al1c),
+    tl4c: normalizeCountValue(item.tl4c),
+    tl3c: normalizeCountValue(item.tl3c),
+    tl2c: normalizeCountValue(item.tl2c),
+    tl1c: normalizeCountValue(item.tl1c),
+    aProcessor: normalizeCountValue(item.aProcessor ?? item.a_processor),
+    tProcessor: normalizeCountValue(item.tProcessor ?? item.t_processor),
+    aNet: normalizeCountValue(item.aNet ?? item.a_net),
+    tNet: normalizeCountValue(item.tNet ?? item.t_net),
+    endgame: normalizeEndgameValue(item.endgame),
+    alreadyUploaded: 1,
+  };
+
+  return { organizationId: organizationId === null ? null : Math.trunc(organizationId), row };
+};
+
 async function syncSuperScoutFields(): Promise<number> {
   const response = await apiRequest<RemoteSuperScoutField[] | null | undefined>(
     '/scout/superscout/fields',
@@ -114,6 +228,73 @@ async function syncSuperScoutFields(): Promise<number> {
   return fields.length;
 }
 
+async function syncPrescoutEntries(eventCode: string, organizationId: number): Promise<number> {
+  const response = await apiRequest<RemotePrescoutResponse[] | null | undefined>(
+    '/scout/prescout',
+    { method: 'GET' },
+  );
+
+  const normalized = Array.isArray(response)
+    ? response
+        .map((item) => normalizePrescoutResponse(item))
+        .filter((entry): entry is NormalizedPrescoutEntry => entry !== null)
+        .filter(
+          (entry) =>
+            entry.row.eventKey === eventCode && entry.organizationId === organizationId,
+        )
+        .map((entry) => entry.row)
+    : [];
+
+  if (normalized.length === 0) {
+    return 0;
+  }
+
+  const db = getDbOrThrow();
+
+  return db.transaction((tx) => {
+    let applied = 0;
+
+    for (const entry of normalized) {
+      const existing = tx
+        .select({ alreadyUploaded: schema.prescoutMatchData2025.alreadyUploaded })
+        .from(schema.prescoutMatchData2025)
+        .where(
+          and(
+            eq(schema.prescoutMatchData2025.eventKey, entry.eventKey),
+            eq(schema.prescoutMatchData2025.teamNumber, entry.teamNumber),
+            eq(schema.prescoutMatchData2025.matchNumber, entry.matchNumber),
+            eq(schema.prescoutMatchData2025.matchLevel, entry.matchLevel),
+          ),
+        )
+        .all()[0];
+
+      if (!existing) {
+        tx.insert(schema.prescoutMatchData2025).values(entry).run();
+        applied += 1;
+        continue;
+      }
+
+      if (existing.alreadyUploaded === 1) {
+        tx
+          .update(schema.prescoutMatchData2025)
+          .set(entry)
+          .where(
+            and(
+              eq(schema.prescoutMatchData2025.eventKey, entry.eventKey),
+              eq(schema.prescoutMatchData2025.teamNumber, entry.teamNumber),
+              eq(schema.prescoutMatchData2025.matchNumber, entry.matchNumber),
+              eq(schema.prescoutMatchData2025.matchLevel, entry.matchLevel),
+            ),
+          )
+          .run();
+        applied += 1;
+      }
+    }
+
+    return applied;
+  });
+}
+
 export async function syncDataWithServer(organizationId: number): Promise<SyncDataWithServerResult> {
   const userEventResponse = await getUserEvent();
   const remoteEventCode = normalizeEventCode(userEventResponse?.eventCode);
@@ -132,6 +313,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
   const db = getDbOrThrow();
 
   const superScoutFieldsSynced = await syncSuperScoutFields();
+  await syncPrescoutEntries(remoteEventCode, organizationId);
 
   let superScoutDataSent = 0;
 
@@ -164,13 +346,37 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
   const prescoutRows = db
     .select()
     .from(schema.prescoutMatchData2025)
-    .where(eq(schema.prescoutMatchData2025.eventKey, remoteEventCode))
+    .where(
+      and(
+        eq(schema.prescoutMatchData2025.eventKey, remoteEventCode),
+        eq(schema.prescoutMatchData2025.alreadyUploaded, 0),
+      ),
+    )
     .all();
 
   if (prescoutRows.length > 0) {
+    const prescoutPayload = prescoutRows.map(({ alreadyUploaded, ...rest }) => rest);
+
     await apiRequest('/scout/prescout/batch', {
       method: 'POST',
-      body: JSON.stringify(prescoutRows),
+      body: JSON.stringify(prescoutPayload),
+    });
+
+    db.transaction((tx) => {
+      for (const row of prescoutRows) {
+        tx
+          .update(schema.prescoutMatchData2025)
+          .set({ alreadyUploaded: 1 })
+          .where(
+            and(
+              eq(schema.prescoutMatchData2025.eventKey, row.eventKey),
+              eq(schema.prescoutMatchData2025.teamNumber, row.teamNumber),
+              eq(schema.prescoutMatchData2025.matchNumber, row.matchNumber),
+              eq(schema.prescoutMatchData2025.matchLevel, row.matchLevel),
+            ),
+          )
+          .run();
+      }
     });
   }
 

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -209,6 +209,7 @@ function initializeExpoSqliteDb() {
       t_processor INTEGER NOT NULL DEFAULT 0,
       a_net INTEGER NOT NULL DEFAULT 0,
       t_net INTEGER NOT NULL DEFAULT 0,
+      already_uploaded INTEGER NOT NULL DEFAULT 0,
       endgame TEXT NOT NULL DEFAULT 'NONE' CHECK (endgame IN ('NONE', 'PARK', 'SHALLOW', 'DEEP')),
       PRIMARY KEY (event_key, team_number, match_number, match_level),
       FOREIGN KEY (event_key) REFERENCES frcevent(event_key),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -322,6 +322,7 @@ export const matchData2025 = sqliteTable(
     tProcessor: integer('t_processor').notNull().default(0),
     aNet: integer('a_net').notNull().default(0),
     tNet: integer('t_net').notNull().default(0),
+    alreadyUploaded: integer('already_uploaded').notNull().default(0),
     endgame: text('endgame', { enum: ['NONE', 'PARK', 'SHALLOW', 'DEEP'] })
       .notNull()
       .default('NONE'),


### PR DESCRIPTION
## Summary
- add an `alreadyUploaded` flag to the prescout match data schema and SQL setup
- download prescout entries from `/scout/prescout` during general sync and merge them without overwriting pending local rows
- send only unsynced prescout rows, marking them uploaded after successful batch or single submissions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a5fe590908326a51f3593808b7a96