### PR TITLE
Add prescout sync tracking

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -17,6 +17,7 @@ import { getDbOrThrow, schema } from '@/db';
 import type { MatchSchedule } from '@/db/schema';
 import { syncAlreadyScoutedEntries } from '../../services/already-scouted';
 import { apiRequest } from '../../services/api';
+import { syncAlreadyPrescoutedEntries } from '../../services/prescouted';
 import { getActiveEvent } from '../../services/logged-in-event';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
@@ -776,6 +777,12 @@ export default function BeginScoutingRoute() {
             });
           } finally {
             clearTimeout(timeoutId);
+          }
+
+          try {
+            await syncAlreadyPrescoutedEntries(normalizedEventKey);
+          } catch (syncError) {
+            console.error('Failed to refresh already prescouted entries from API', syncError);
           }
 
           Alert.alert('Prescout submitted', 'Prescout data was saved and sent successfully.', [

--- a/app/screens/Shared/TeamListScreen.tsx
+++ b/app/screens/Shared/TeamListScreen.tsx
@@ -134,12 +134,12 @@ export function TeamListScreen({
     if (showPrescoutProgress) {
       const prescoutRows = db
         .select({
-          teamNumber: schema.prescoutMatchData2025.teamNumber,
+          teamNumber: schema.alreadyPrescouteds.teamNumber,
           matchCount: sql<number>`count(*)`.as('matchCount'),
         })
-        .from(schema.prescoutMatchData2025)
-        .where(eq(schema.prescoutMatchData2025.eventKey, eventKey))
-        .groupBy(schema.prescoutMatchData2025.teamNumber)
+        .from(schema.alreadyPrescouteds)
+        .where(eq(schema.alreadyPrescouteds.eventKey, eventKey))
+        .groupBy(schema.alreadyPrescouteds.teamNumber)
         .all();
 
       prescoutRows.forEach((row) => {

--- a/app/services/prescouted.ts
+++ b/app/services/prescouted.ts
@@ -1,0 +1,87 @@
+import { apiRequest } from './api';
+import { getDbOrThrow, schema } from '@/db';
+
+export type AlreadyPrescoutedResponse = {
+  event_key?: string | null;
+  team_number?: number | string | null;
+  match_number?: number | string | null;
+  match_level?: string | null;
+};
+
+const normalizeNumber = (value: number | string | null | undefined): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const normalizeAlreadyPrescouted = (
+  item: AlreadyPrescoutedResponse,
+): typeof schema.alreadyPrescouteds.$inferInsert | null => {
+  const eventKey = typeof item.event_key === 'string' ? item.event_key.trim() : '';
+  const matchLevel = typeof item.match_level === 'string' ? item.match_level.trim() : '';
+  const teamNumber = normalizeNumber(item.team_number);
+  const matchNumber = normalizeNumber(item.match_number);
+
+  if (!eventKey || !matchLevel || teamNumber === null || matchNumber === null) {
+    return null;
+  }
+
+  return {
+    eventKey,
+    matchLevel,
+    teamNumber,
+    matchNumber,
+  };
+};
+
+export async function syncAlreadyPrescoutedEntries(eventKey: string): Promise<number> {
+  const response = await apiRequest<AlreadyPrescoutedResponse[]>('/scout/prescout', {
+    method: 'GET',
+  });
+
+  const desiredEventKey = eventKey.trim();
+
+  const entries = Array.isArray(response)
+    ? response
+        .map((item) => normalizeAlreadyPrescouted(item))
+        .filter((entry): entry is typeof schema.alreadyPrescouteds.$inferInsert => !!entry)
+        .filter((entry) => !desiredEventKey || entry.eventKey === desiredEventKey)
+    : [];
+
+  if (entries.length === 0) {
+    return 0;
+  }
+
+  const db = getDbOrThrow();
+
+  return db.transaction((tx) => {
+    let inserted = 0;
+
+    for (const entry of entries) {
+      const result = tx
+        .insert(schema.alreadyPrescouteds)
+        .values(entry)
+        .onConflictDoNothing()
+        .run();
+
+      if (result.rowsAffected > 0) {
+        inserted += 1;
+      }
+    }
+
+    return inserted;
+  });
+}

--- a/app/services/sync-data.ts
+++ b/app/services/sync-data.ts
@@ -4,6 +4,7 @@ import { retrieveEventInfo, type RetrieveEventInfoResult } from './event-info';
 import { syncPickLists, type SyncPickListsResult } from './pick-lists';
 import { getActiveEvent, setActiveEvent } from './logged-in-event';
 import { syncAlreadyScoutedEntries } from './already-scouted';
+import { syncAlreadyPrescoutedEntries } from './prescouted';
 import { syncAlreadyPitScoutedEntries } from './pit-scouting';
 import { syncPendingRobotPhotos } from './robot-photos';
 import { getDbOrThrow, schema } from '@/db';
@@ -18,6 +19,7 @@ export type SyncDataWithServerResult = {
   prescoutDataSent: number;
   superScoutDataSent: number;
   alreadyScoutedUpdated: number;
+  alreadyPrescoutedUpdated: number;
   alreadyPitScoutedUpdated: number;
   alreadySuperScoutedUpdated: number;
   robotPhotosUploaded: number;
@@ -278,6 +280,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
   }
 
   const alreadyScoutedUpdated = await syncAlreadyScoutedEntries(organizationId);
+  const alreadyPrescoutedUpdated = await syncAlreadyPrescoutedEntries(remoteEventCode);
   const alreadyPitScoutedUpdated = await syncAlreadyPitScoutedEntries(organizationId);
   const alreadySuperScoutedUpdated = eventInfo.alreadySuperScouted.created;
   const robotPhotosUploaded = await syncPendingRobotPhotos();
@@ -291,6 +294,7 @@ export async function syncDataWithServer(organizationId: number): Promise<SyncDa
     prescoutDataSent: prescoutRows.length,
     superScoutDataSent,
     alreadyScoutedUpdated,
+    alreadyPrescoutedUpdated,
     alreadyPitScoutedUpdated,
     alreadySuperScoutedUpdated,
     robotPhotosUploaded,

--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -124,7 +124,7 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
         `Team list: received ${result.eventInfo.teamEvents.received}, created ${result.eventInfo.teamEvents.created}, removed ${result.eventInfo.teamEvents.removed}`,
       ].join('\n');
 
-      const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}, super ${result.alreadySuperScoutedUpdated}`;
+      const alreadyScoutedSummary = `Already scouted updates: matches ${result.alreadyScoutedUpdated}, prescout ${result.alreadyPrescoutedUpdated}, pit ${result.alreadyPitScoutedUpdated}, super ${result.alreadySuperScoutedUpdated}`;
       const pickListSummary = `Pick lists: received ${result.pickLists.received}, created ${result.pickLists.created}, updated ${result.pickLists.updated}, removed ${result.pickLists.removed}`;
       const submissionSummary = `Submitted ${result.matchDataSent} match entries, ${result.pitDataSent} pit entries, ${result.prescoutDataSent} prescout entries, ${result.superScoutDataSent} SuperScout entries.`;
 

--- a/db/index.shared.ts
+++ b/db/index.shared.ts
@@ -242,6 +242,15 @@ function initializeExpoSqliteDb() {
       PRIMARY KEY (event_code, match_level, match_number, alliance),
       FOREIGN KEY (event_code) REFERENCES frcevent(event_key)
     );`,
+    `CREATE TABLE IF NOT EXISTS already_prescouted (
+      event_key TEXT NOT NULL,
+      team_number INTEGER NOT NULL,
+      match_number INTEGER NOT NULL,
+      match_level TEXT NOT NULL,
+      PRIMARY KEY (event_key, team_number, match_number, match_level),
+      FOREIGN KEY (event_key) REFERENCES frcevent(event_key),
+      FOREIGN KEY (team_number) REFERENCES teamrecord(team_number)
+    );`,
     `CREATE TABLE IF NOT EXISTS prescoutmatchdata2025 (
       event_key TEXT NOT NULL,
       team_number INTEGER NOT NULL,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -441,6 +441,34 @@ export const alreadySuperScouteds = sqliteTable(
 export type AlreadySuperScouted = InferSelectModel<typeof alreadySuperScouteds>;
 export type NewAlreadySuperScouted = InferInsertModel<typeof alreadySuperScouteds>;
 
+export const alreadyPrescouteds = sqliteTable(
+  'already_prescouted',
+  {
+    eventKey: text('event_key').notNull(),
+    teamNumber: integer('team_number').notNull(),
+    matchNumber: integer('match_number').notNull(),
+    matchLevel: text('match_level').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({
+      columns: [table.eventKey, table.teamNumber, table.matchNumber, table.matchLevel],
+    }),
+    eventRef: foreignKey({
+      columns: [table.eventKey],
+      foreignColumns: [frcEvents.eventKey],
+      name: 'already_prescouted_event_fk',
+    }),
+    teamRef: foreignKey({
+      columns: [table.teamNumber],
+      foreignColumns: [teamRecords.teamNumber],
+      name: 'already_prescouted_team_fk',
+    }),
+  })
+);
+
+export type AlreadyPrescouted = InferSelectModel<typeof alreadyPrescouteds>;
+export type NewAlreadyPrescouted = InferInsertModel<typeof alreadyPrescouteds>;
+
 export const prescoutMatchData2025 = sqliteTable(
   'prescoutmatchdata2025',
   {


### PR DESCRIPTION
## Summary
- add a local already_prescouted table and schema initialization to mirror server data
- add a prescout sync service and integrate it with the general sync flow and prescout submissions
- surface prescout completion counts from the new table in the team list and sync summary

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_690a62cfc7dc8326ac7cd86a8bc51f18