### PR TITLE
Add Begin Scouting button to match scout info tab

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -1133,6 +1133,22 @@ export default function BeginScoutingRoute() {
                 </View>
               ))}
             </View>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setSelectedTab('auto')}
+              style={({ pressed }) => [
+                styles.beginScoutingButton,
+                { backgroundColor: toggleActiveBackground },
+                pressed && styles.buttonPressed,
+              ]}
+            >
+              <ThemedText
+                type="defaultSemiBold"
+                style={[styles.beginScoutingButtonText, { color: toggleActiveTextColor }]}
+              >
+                Begin Scouting
+              </ThemedText>
+            </Pressable>
           </View>
         ) : null}
 
@@ -1448,6 +1464,16 @@ const styles = StyleSheet.create({
   },
   infoSection: {
     gap: 16,
+  },
+  beginScoutingButton: {
+    borderRadius: 12,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    alignItems: 'center',
+    alignSelf: 'center',
+  },
+  beginScoutingButtonText: {
+    fontSize: 16,
   },
   infoCard: {
     borderWidth: 1,


### PR DESCRIPTION
## Summary
- add a Begin Scouting button to the Match Scout Info tab that switches to the Autonomous tab
- style the new button to match the existing theming

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a684cce688326b4ffdc37050e4ea4