### PR TITLE
Refresh active drawer tab after syncing data

### DIFF
--- a/components/layout/AppDrawerContent.tsx
+++ b/components/layout/AppDrawerContent.tsx
@@ -119,6 +119,13 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
 
       navigation.closeDrawer();
 
+      const activeDrawerItem = drawerItems.find(
+        (item) => item.name === activeRouteName,
+      );
+      if (activeDrawerItem) {
+        router.replace(activeDrawerItem.href);
+      }
+
       const eventInfoSummary = [
         `Match schedule: received ${result.eventInfo.matchSchedule.received}, created ${result.eventInfo.matchSchedule.created}, updated ${result.eventInfo.matchSchedule.updated}, removed ${result.eventInfo.matchSchedule.removed}`,
         `Team list: received ${result.eventInfo.teamEvents.received}, created ${result.eventInfo.teamEvents.created}, removed ${result.eventInfo.teamEvents.removed}`,
@@ -144,6 +151,8 @@ export function AppDrawerContent({ state, navigation }: DrawerContentProps) {
       setIsSyncing(false);
     }
   }, [
+    activeRouteName,
+    drawerItems,
     isAuthenticated,
     isSyncing,
     navigation,


### PR DESCRIPTION
## Summary
- refresh the currently open drawer route after a successful data sync
- include the active route and drawer items in the sync handler dependencies to keep references current

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690a75dbbed88326baba5ef9dbd1f096