### PR TITLE
Add persistent Left Handed Mode for match scouting counters

### DIFF
--- a/app/(drawer)/match-scout/begin-scouting.tsx
+++ b/app/(drawer)/match-scout/begin-scouting.tsx
@@ -25,6 +25,7 @@ import { ScreenContainer } from "@/components/layout/ScreenContainer";
 import { ThemedText } from "@/components/themed-text";
 import { useOrganization } from "@/hooks/use-organization";
 import { useThemeColor } from "@/hooks/use-theme-color";
+import { useLeftHandedMode } from "@/hooks/use-app-settings";
 
 const toSingleValue = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
@@ -389,6 +390,7 @@ interface CounterControlProps {
   onDecrementByTwenty: () => void;
   leftFooter?: ReactNode;
   rightFooter?: ReactNode;
+  incrementsOnRight?: boolean;
 }
 
 function CounterControl({
@@ -402,6 +404,7 @@ function CounterControl({
   onDecrementByTwenty,
   leftFooter,
   rightFooter,
+  incrementsOnRight = true,
 }: CounterControlProps) {
   const positiveBackground = useThemeColor(
     { light: "#475569", dark: "#1F2937" },
@@ -415,108 +418,217 @@ function CounterControl({
   return (
     <View style={styles.counterControl}>
       <View style={styles.counterButtonsSplit}>
-        <View style={styles.counterButtonsColumn}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onIncrement}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonPositive,
-              styles.counterButtonCompact,
-              { backgroundColor: positiveBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterLabel}>
-              {label}
-            </ThemedText>
-            <ThemedText type="title" style={styles.counterValue}>
-              {value}
-            </ThemedText>
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              +1
-            </ThemedText>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onIncrementByFive}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonPositive,
-              styles.counterButtonCompact,
-              { backgroundColor: positiveBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              +5
-            </ThemedText>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onIncrementByTwenty}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonPositive,
-              styles.counterButtonCompact,
-              { backgroundColor: positiveBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              +20
-            </ThemedText>
-          </Pressable>
-          {leftFooter}
-        </View>
-        <View style={styles.counterButtonsColumn}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onDecrementByOne}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonNegative,
-              styles.counterButtonCompact,
-              { backgroundColor: negativeBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              -1
-            </ThemedText>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onDecrementByFive}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonNegative,
-              styles.counterButtonCompact,
-              { backgroundColor: negativeBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              -5
-            </ThemedText>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            onPress={onDecrementByTwenty}
-            style={({ pressed }) => [
-              styles.counterButton,
-              styles.counterButtonNegative,
-              styles.counterButtonCompact,
-              { backgroundColor: negativeBackground },
-              pressed && styles.buttonPressed,
-            ]}
-          >
-            <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
-              -20
-            </ThemedText>
-          </Pressable>
-          {rightFooter}
-        </View>
+        {incrementsOnRight ? (
+          <>
+            <View style={styles.counterButtonsColumn}>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByOne}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -1
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByFive}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -5
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByTwenty}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -20
+                </ThemedText>
+              </Pressable>
+              {leftFooter}
+            </View>
+            <View style={styles.counterButtonsColumn}>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrement}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterLabel}>
+                  {label}
+                </ThemedText>
+                <ThemedText type="title" style={styles.counterValue}>
+                  {value}
+                </ThemedText>
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +1
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrementByFive}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +5
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrementByTwenty}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +20
+                </ThemedText>
+              </Pressable>
+              {rightFooter}
+            </View>
+          </>
+        ) : (
+          <>
+            <View style={styles.counterButtonsColumn}>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrement}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterLabel}>
+                  {label}
+                </ThemedText>
+                <ThemedText type="title" style={styles.counterValue}>
+                  {value}
+                </ThemedText>
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +1
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrementByFive}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +5
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onIncrementByTwenty}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonPositive,
+                  styles.counterButtonCompact,
+                  { backgroundColor: positiveBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  +20
+                </ThemedText>
+              </Pressable>
+              {leftFooter}
+            </View>
+            <View style={styles.counterButtonsColumn}>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByOne}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -1
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByFive}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -5
+                </ThemedText>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                onPress={onDecrementByTwenty}
+                style={({ pressed }) => [
+                  styles.counterButton,
+                  styles.counterButtonNegative,
+                  styles.counterButtonCompact,
+                  { backgroundColor: negativeBackground },
+                  pressed && styles.buttonPressed,
+                ]}
+              >
+                <ThemedText type="defaultSemiBold" style={styles.counterButtonText}>
+                  -20
+                </ThemedText>
+              </Pressable>
+              {rightFooter}
+            </View>
+          </>
+        )}
       </View>
     </View>
   );
@@ -526,6 +638,7 @@ export default function BeginScoutingRoute() {
   const params = useLocalSearchParams<BeginScoutingParams>();
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
   const router = useRouter();
+  const leftHandedMode = useLeftHandedMode();
 
   const mode = toSingleValue(params.mode);
   const isPrescoutMode = mode === "prescout";
@@ -1312,6 +1425,7 @@ export default function BeginScoutingRoute() {
                     onDecrementByOne={() => handleAdjust("fuelScored", -1)}
                     onDecrementByFive={() => handleAdjust("fuelScored", -5)}
                     onDecrementByTwenty={() => handleAdjust("fuelScored", -20)}
+                    incrementsOnRight={!leftHandedMode}
                     leftFooter={
                       <>
                         {isAutoTab ? (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,7 +26,7 @@ WebBrowser.maybeCompleteAuthSession();
 (SecureStore as typeof SecureStore & { default?: typeof SecureStore }).default ??= SecureStore;
 
 type ProvidersModule = typeof import('@/app/providers');
-const { AuthProvider, OrganizationProvider, QueryProvider, ColorSchemeProvider } =
+const { AuthProvider, OrganizationProvider, QueryProvider, ColorSchemeProvider, AppSettingsProvider } =
   require('@/app/providers') as ProvidersModule;
 
 type UseColorSchemeModule = typeof import('@/hooks/use-color-scheme');
@@ -48,7 +48,9 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <ColorSchemeProvider>
-        <ThemedRootLayout />
+        <AppSettingsProvider>
+          <ThemedRootLayout />
+        </AppSettingsProvider>
       </ColorSchemeProvider>
     </SafeAreaProvider>
   );

--- a/app/providers/AppSettingsProvider.tsx
+++ b/app/providers/AppSettingsProvider.tsx
@@ -1,0 +1,70 @@
+import * as SecureStore from 'expo-secure-store';
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type PropsWithChildren,
+  type SetStateAction,
+} from 'react';
+
+type AppSettingsContextValue = {
+  leftHandedMode: boolean;
+  setLeftHandedMode: Dispatch<SetStateAction<boolean>>;
+};
+
+const LEFT_HANDED_MODE_KEY = 'app_setting_left_handed_mode';
+
+export const AppSettingsContext = createContext<AppSettingsContextValue | null>(null);
+
+export function AppSettingsProvider({ children }: PropsWithChildren) {
+  const [leftHandedMode, setLeftHandedModeState] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadSetting = async () => {
+      try {
+        const storedValue = await SecureStore.getItemAsync(LEFT_HANDED_MODE_KEY);
+
+        if (!isMounted || storedValue === null) {
+          return;
+        }
+
+        setLeftHandedModeState(storedValue === 'true');
+      } catch (error) {
+        console.warn('Failed to load left-handed mode setting', error);
+      }
+    };
+
+    void loadSetting();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const setLeftHandedMode = useCallback((value: SetStateAction<boolean>) => {
+    setLeftHandedModeState((previousValue) => {
+      const nextValue = typeof value === 'function' ? value(previousValue) : value;
+
+      void SecureStore.setItemAsync(LEFT_HANDED_MODE_KEY, String(nextValue)).catch((error) => {
+        console.warn('Failed to save left-handed mode setting', error);
+      });
+
+      return nextValue;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      leftHandedMode,
+      setLeftHandedMode,
+    }),
+    [leftHandedMode, setLeftHandedMode],
+  );
+
+  return <AppSettingsContext.Provider value={value}>{children}</AppSettingsContext.Provider>;
+}

--- a/app/providers/index.ts
+++ b/app/providers/index.ts
@@ -2,3 +2,5 @@ export { AuthProvider } from './AuthProvider';
 export { OrganizationProvider } from './OrganizationProvider';
 export { QueryProvider } from './QueryProvider';
 export { ColorSchemeProvider } from './ColorSchemeProvider';
+
+export { AppSettingsProvider } from './AppSettingsProvider';

--- a/app/screens/Settings/AppSettingsScreen.tsx
+++ b/app/screens/Settings/AppSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, Switch, View } from 'react-native';
 
 import { ScreenContainer } from '@/components/layout/ScreenContainer';
 import { ThemedText } from '@/components/themed-text';
@@ -7,16 +7,37 @@ import {
   useColorSchemePreference,
   useSetColorSchemePreference,
 } from '@/hooks/use-color-scheme';
+import { useLeftHandedMode, useSetLeftHandedMode } from '@/hooks/use-app-settings';
 
 export function AppSettingsScreen() {
   const colorScheme = useColorScheme();
   const preference = useColorSchemePreference();
   const setPreference = useSetColorSchemePreference();
+  const leftHandedMode = useLeftHandedMode();
+  const setLeftHandedMode = useSetLeftHandedMode();
 
   return (
     <ScreenContainer>
       <ThemedText type="title">App Settings</ThemedText>
       <ThemedText>Choose how the app should look on your device.</ThemedText>
+
+
+      <View style={styles.section}>
+        <ThemedText style={styles.sectionLabel}>Match Scouting</ThemedText>
+        <View style={styles.switchRow}>
+          <View style={styles.switchTextContainer}>
+            <ThemedText style={styles.optionLabel}>Left Handed Mode</ThemedText>
+            <ThemedText style={styles.optionDescription}>
+              Flips increment/decrement button sides while scouting matches.
+            </ThemedText>
+          </View>
+          <Switch
+            value={leftHandedMode}
+            onValueChange={setLeftHandedMode}
+            accessibilityLabel="Toggle Left Handed Mode"
+          />
+        </View>
+      </View>
 
       <View style={styles.section}>
         <ThemedText style={styles.sectionLabel}>Appearance</ThemedText>
@@ -112,5 +133,19 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
     opacity: 0.8,
+  },
+  switchRow: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#CBD5F5',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  switchTextContainer: {
+    flex: 1,
   },
 });

--- a/hooks/use-app-settings.ts
+++ b/hooks/use-app-settings.ts
@@ -1,0 +1,23 @@
+import { useContext } from 'react';
+
+import { AppSettingsContext } from '@/app/providers/AppSettingsProvider';
+
+export function useLeftHandedMode() {
+  const context = useContext(AppSettingsContext);
+
+  if (!context) {
+    return false;
+  }
+
+  return context.leftHandedMode;
+}
+
+export function useSetLeftHandedMode() {
+  const context = useContext(AppSettingsContext);
+
+  if (!context) {
+    throw new Error('useSetLeftHandedMode must be used within an AppSettingsProvider.');
+  }
+
+  return context.setLeftHandedMode;
+}


### PR DESCRIPTION
### Motivation
- Provide a persistent app setting that lets users flip increment and decrement button placement for match scouting so left-handed users have a comfortable layout.
- Default behavior keeps increments on the right and allows the preference to survive app restarts.

### Description
- Add an `AppSettingsProvider` that persists `leftHandedMode` using `expo-secure-store` and exposes the setting via context and setter functions.
- Add `useLeftHandedMode` and `useSetLeftHandedMode` hooks to read and update the setting from components.
- Wire the provider into the app root so the setting is available everywhere by wrapping `ThemedRootLayout` with `AppSettingsProvider` in `app/_layout.tsx`.
- Add a `Left Handed Mode` toggle to the App Settings under a new "Match Scouting" section, and update the match-scout counters to place increments on the right by default and flip sides when the setting is enabled.

### Testing
- Ran `npm run lint`, which completed successfully; the repo still reports existing lint warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40d290e688326933e7af3f21dd8ad)