### PR TITLE
Defer robot photo upsert until after event/team bootstrap to avoid FK failures

### DIFF
--- a/app/services/event-info.ts
+++ b/app/services/event-info.ts
@@ -351,8 +351,8 @@ export async function retrieveEventInfo(): Promise<RetrieveEventInfoResult> {
     }
   }
 
-  const { inserted: alreadyRobotPhotosInserted, received: alreadyRobotPhotosReceived } =
-    upsertAlreadyRobotPhotos(eventCode, rawEventImages);
+  let alreadyRobotPhotosInserted = 0;
+  let alreadyRobotPhotosReceived = 0;
 
   const matchScheduleResult: RetrieveEventInfoResult['matchSchedule'] = {
     received: normalizedMatchMap.size,
@@ -602,6 +602,12 @@ export async function retrieveEventInfo(): Promise<RetrieveEventInfoResult> {
       }
     }
   });
+
+  const robotPhotosResult = upsertAlreadyRobotPhotos(eventCode, rawEventImages);
+  alreadyRobotPhotosInserted = robotPhotosResult.inserted;
+  alreadyRobotPhotosReceived = robotPhotosResult.received;
+  alreadyRobotPhotosResult.received = alreadyRobotPhotosReceived;
+  alreadyRobotPhotosResult.created = alreadyRobotPhotosInserted;
 
   return {
     eventCode,


### PR DESCRIPTION
### Motivation
- Data sync could fail with `FOREIGN KEY constraint failed` when robot photo rows were inserted before placeholder `teamRecords` or `frcEvents` rows existed locally.

### Description
- Move the call to `upsertAlreadyRobotPhotos(eventCode, rawEventImages)` to run after the transaction that inserts/ensures required `teamRecords` and `frcEvents` rows in `app/services/event-info.ts`.
- Initialize `alreadyRobotPhotosInserted` and `alreadyRobotPhotosReceived` before the transaction and populate them from the deferred `upsertAlreadyRobotPhotos` result so the `alreadyRobotPhotos` result object reflects the actual upsert counts.
- Keep the existing transaction that bootstraps teams/events intact and perform the robot photo upsert outside it so foreign key constraints are satisfied when inserting photo rows.

### Testing
- Ran `npm run lint`, which completed successfully (repo has unrelated pre-existing warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43108e348832686814561fa255637)